### PR TITLE
Add EU exit business finder metadata tags to all relevant schemas

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -320,6 +320,9 @@
         },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -565,6 +568,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -370,6 +370,9 @@
         },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -668,6 +671,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -176,6 +176,9 @@
         },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -386,6 +389,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -699,7 +699,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -712,6 +739,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -792,7 +792,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -805,6 +832,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -450,7 +450,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -463,6 +490,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -759,7 +759,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -772,6 +799,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -857,7 +857,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -870,6 +897,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -607,7 +607,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -620,6 +647,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -661,7 +661,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -674,6 +701,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -748,7 +748,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -761,6 +788,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -501,7 +501,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -514,6 +541,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -708,7 +708,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -721,6 +748,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -801,7 +801,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -814,6 +841,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -525,7 +525,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -538,6 +565,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -645,7 +645,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -658,6 +685,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -740,7 +740,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -753,6 +780,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -487,7 +487,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -500,6 +527,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -611,7 +611,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -624,6 +651,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -695,7 +695,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -708,6 +735,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -413,7 +413,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -426,6 +453,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -325,6 +325,9 @@
         "parts": {
           "description": "List of guide parts",
           "$ref": "#/definitions/parts"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -594,6 +597,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -375,6 +375,9 @@
         "parts": {
           "description": "List of guide parts",
           "$ref": "#/definitions/parts"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -697,6 +700,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -181,6 +181,9 @@
         "parts": {
           "description": "List of guide parts",
           "$ref": "#/definitions/parts"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -415,6 +418,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -662,7 +662,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -675,6 +702,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -746,7 +746,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -759,6 +786,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -464,7 +464,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -477,6 +504,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -332,6 +332,9 @@
         },
         "section_id": {
           "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -654,6 +657,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -382,6 +382,9 @@
         },
         "section_id": {
           "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -738,6 +741,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -188,6 +188,9 @@
         },
         "section_id": {
           "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -456,6 +459,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -335,6 +335,9 @@
           "type": "string",
           "format": "date-time"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "web_isbn": {
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication",
           "type": "string"
@@ -560,6 +563,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -382,6 +382,9 @@
           "type": "string",
           "format": "date-time"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "web_isbn": {
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication",
           "type": "string"
@@ -641,6 +644,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -209,6 +209,9 @@
           "type": "string",
           "format": "date-time"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "web_isbn": {
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication",
           "type": "string"
@@ -380,6 +383,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -337,6 +337,9 @@
           "description": "One line curated description, will appear in Licence Finder results.",
           "type": "string"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "will_continue_on": {
           "$ref": "#/definitions/will_continue_on"
         }
@@ -584,6 +587,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -387,6 +387,9 @@
           "description": "One line curated description, will appear in Licence Finder results.",
           "type": "string"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "will_continue_on": {
           "$ref": "#/definitions/will_continue_on"
         }
@@ -687,6 +690,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -193,6 +193,9 @@
           "description": "One line curated description, will appear in Licence Finder results.",
           "type": "string"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "will_continue_on": {
           "$ref": "#/definitions/will_continue_on"
         }
@@ -405,6 +408,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -363,6 +363,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -608,6 +611,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -413,6 +413,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -711,6 +714,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -219,6 +219,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -429,6 +432,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -330,6 +330,9 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -644,6 +647,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -385,6 +385,9 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -752,6 +755,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -185,6 +185,9 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -464,6 +467,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -368,6 +368,9 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -627,6 +630,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -423,6 +423,9 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -735,6 +738,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -223,6 +223,9 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -447,6 +450,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -735,7 +735,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -748,6 +775,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -846,7 +846,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -859,6 +886,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -497,7 +497,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -510,6 +537,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -830,7 +830,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -843,6 +870,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -918,7 +918,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -931,6 +958,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -632,7 +632,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -645,6 +672,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -764,7 +764,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -777,6 +804,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -868,7 +868,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -881,6 +908,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -546,7 +546,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -559,6 +586,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -382,6 +382,9 @@
         },
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -631,6 +634,94 @@
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -432,6 +432,9 @@
         },
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -734,6 +737,94 @@
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -238,6 +238,9 @@
         },
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -452,6 +455,94 @@
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -297,6 +297,9 @@
         "aircraft_type": {
           "type": "string"
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -304,11 +307,53 @@
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "location": {
           "type": "string"
         },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "registration": {
           "type": "string"
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "report_type": {
           "type": "string",
@@ -322,6 +367,12 @@
             "special-bulletin",
             "safety-study"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -446,11 +497,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -514,6 +616,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -543,6 +648,18 @@
         "continuation_link": {
           "type": "string"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "industries": {
           "type": "array",
           "items": {
@@ -568,6 +685,30 @@
             ]
           }
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "regions": {
           "type": "array",
           "items": {
@@ -585,6 +726,18 @@
               "west-midlands",
               "yorkshire-and-the-humber"
             ]
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "types_of_support": {
@@ -638,6 +791,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -664,6 +820,24 @@
         "closed_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "market_sector": {
           "type": "array",
@@ -739,6 +913,36 @@
             "consumer-enforcement-changes-to-business-practices-agreed",
             "regulatory-references-and-appeals-final-determination"
           ]
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -746,8 +950,23 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "funding_amount": {
           "type": "array",
@@ -773,6 +992,12 @@
             "supplement"
           ]
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "land_use": {
           "type": "array",
           "items": {
@@ -795,6 +1020,36 @@
               "wildlife-package",
               "woodland"
             ]
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "tiers_or_standalone_items": {
@@ -860,6 +1115,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -1130,9 +1388,57 @@
             ]
           }
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "first_published_at": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1140,12 +1446,63 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "first_published_at": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "therapeutic_area": {
           "type": "array",
@@ -1184,11 +1541,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1219,11 +1627,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1248,12 +1707,27 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "closing_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "fund_state": {
           "type": "string",
@@ -1294,6 +1768,12 @@
             ]
           }
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "location": {
           "type": "array",
           "items": {
@@ -1310,6 +1790,36 @@
               "london"
             ]
           }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1317,6 +1827,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "certificate_status": {
           "type": "string",
           "enum": [
@@ -1564,6 +2077,54 @@
               "zimbabwe"
             ]
           }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1647,6 +2208,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -1673,6 +2237,12 @@
             ]
           }
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "eligible_entities": {
           "type": "array",
           "items": {
@@ -1689,12 +2259,24 @@
             ]
           }
         },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "fund_state": {
           "type": "string",
           "enum": [
             "open",
             "closed"
           ]
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "location": {
           "type": "array",
@@ -1901,6 +2483,36 @@
             ]
           }
         },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "value_of_funding": {
           "type": "array",
           "items": {
@@ -1974,12 +2586,57 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "report_type": {
           "type": "string",
@@ -1990,6 +2647,12 @@
             "overseas-report",
             "discontinued-investigation"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "vessel_type": {
           "type": "array",
@@ -2023,8 +2686,29 @@
             "company-led-drugs"
           ]
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "issued_date": {
           "type": "string",
@@ -2058,6 +2742,36 @@
               "urology",
               "vascular-cardiac-surgery"
             ]
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -2150,12 +2864,45 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "railway_type": {
           "type": "array",
@@ -2169,6 +2916,18 @@
             ]
           }
         },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "report_type": {
           "type": "string",
           "enum": [
@@ -2178,6 +2937,12 @@
             "discontinuation-report",
             "safety-digest"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2213,11 +2978,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2294,12 +3110,63 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "assessment_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2307,9 +3174,60 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "laid_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "sift_end_date": {
           "type": "string",
@@ -2360,11 +3278,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2390,11 +3359,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -352,6 +352,9 @@
         "aircraft_type": {
           "type": "string"
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -359,11 +362,53 @@
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "location": {
           "type": "string"
         },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "registration": {
           "type": "string"
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "report_type": {
           "type": "string",
@@ -377,6 +422,12 @@
             "special-bulletin",
             "safety-study"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -501,11 +552,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -569,6 +671,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -598,6 +703,18 @@
         "continuation_link": {
           "type": "string"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "industries": {
           "type": "array",
           "items": {
@@ -623,6 +740,30 @@
             ]
           }
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "regions": {
           "type": "array",
           "items": {
@@ -640,6 +781,18 @@
               "west-midlands",
               "yorkshire-and-the-humber"
             ]
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "types_of_support": {
@@ -693,6 +846,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -719,6 +875,24 @@
         "closed_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "market_sector": {
           "type": "array",
@@ -794,6 +968,36 @@
             "consumer-enforcement-changes-to-business-practices-agreed",
             "regulatory-references-and-appeals-final-determination"
           ]
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -801,8 +1005,23 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "funding_amount": {
           "type": "array",
@@ -828,6 +1047,12 @@
             "supplement"
           ]
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "land_use": {
           "type": "array",
           "items": {
@@ -850,6 +1075,36 @@
               "wildlife-package",
               "woodland"
             ]
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "tiers_or_standalone_items": {
@@ -915,6 +1170,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -1185,9 +1443,57 @@
             ]
           }
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "first_published_at": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1195,12 +1501,63 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "first_published_at": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "therapeutic_area": {
           "type": "array",
@@ -1239,11 +1596,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1274,11 +1682,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1303,12 +1762,27 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "closing_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "fund_state": {
           "type": "string",
@@ -1349,6 +1823,12 @@
             ]
           }
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "location": {
           "type": "array",
           "items": {
@@ -1365,6 +1845,36 @@
               "london"
             ]
           }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1372,6 +1882,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "certificate_status": {
           "type": "string",
           "enum": [
@@ -1619,6 +2132,54 @@
               "zimbabwe"
             ]
           }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1715,6 +2276,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -1741,6 +2305,12 @@
             ]
           }
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "eligible_entities": {
           "type": "array",
           "items": {
@@ -1757,12 +2327,24 @@
             ]
           }
         },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "fund_state": {
           "type": "string",
           "enum": [
             "open",
             "closed"
           ]
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "location": {
           "type": "array",
@@ -1969,6 +2551,36 @@
             ]
           }
         },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "value_of_funding": {
           "type": "array",
           "items": {
@@ -2042,12 +2654,57 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "report_type": {
           "type": "string",
@@ -2058,6 +2715,12 @@
             "overseas-report",
             "discontinued-investigation"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "vessel_type": {
           "type": "array",
@@ -2091,8 +2754,29 @@
             "company-led-drugs"
           ]
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "issued_date": {
           "type": "string",
@@ -2126,6 +2810,36 @@
               "urology",
               "vascular-cardiac-surgery"
             ]
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -2236,12 +2950,45 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "railway_type": {
           "type": "array",
@@ -2255,6 +3002,18 @@
             ]
           }
         },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "report_type": {
           "type": "string",
           "enum": [
@@ -2264,6 +3023,12 @@
             "discontinuation-report",
             "safety-digest"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2299,11 +3064,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2402,12 +3218,63 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "assessment_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2415,9 +3282,60 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "laid_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "sift_end_date": {
           "type": "string",
@@ -2468,11 +3386,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2505,11 +3474,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -170,6 +170,9 @@
         "aircraft_type": {
           "type": "string"
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -177,11 +180,53 @@
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "location": {
           "type": "string"
         },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "registration": {
           "type": "string"
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "report_type": {
           "type": "string",
@@ -195,6 +240,12 @@
             "special-bulletin",
             "safety-study"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -335,11 +386,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -403,6 +505,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -432,6 +537,18 @@
         "continuation_link": {
           "type": "string"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "industries": {
           "type": "array",
           "items": {
@@ -457,6 +574,30 @@
             ]
           }
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "regions": {
           "type": "array",
           "items": {
@@ -474,6 +615,18 @@
               "west-midlands",
               "yorkshire-and-the-humber"
             ]
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "types_of_support": {
@@ -527,6 +680,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -553,6 +709,24 @@
         "closed_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "market_sector": {
           "type": "array",
@@ -628,6 +802,36 @@
             "consumer-enforcement-changes-to-business-practices-agreed",
             "regulatory-references-and-appeals-final-determination"
           ]
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -635,8 +839,23 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "funding_amount": {
           "type": "array",
@@ -662,6 +881,12 @@
             "supplement"
           ]
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "land_use": {
           "type": "array",
           "items": {
@@ -684,6 +909,36 @@
               "wildlife-package",
               "woodland"
             ]
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "tiers_or_standalone_items": {
@@ -749,6 +1004,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -1019,9 +1277,57 @@
             ]
           }
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "first_published_at": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1029,12 +1335,63 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "first_published_at": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "therapeutic_area": {
           "type": "array",
@@ -1073,11 +1430,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1108,11 +1516,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1137,12 +1596,27 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "closing_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "fund_state": {
           "type": "string",
@@ -1183,6 +1657,12 @@
             ]
           }
         },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "location": {
           "type": "array",
           "items": {
@@ -1199,6 +1679,36 @@
               "london"
             ]
           }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1206,6 +1716,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "certificate_status": {
           "type": "string",
           "enum": [
@@ -1453,6 +1966,54 @@
               "zimbabwe"
             ]
           }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1476,6 +2037,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -1502,6 +2066,12 @@
             ]
           }
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "eligible_entities": {
           "type": "array",
           "items": {
@@ -1518,12 +2088,24 @@
             ]
           }
         },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "fund_state": {
           "type": "string",
           "enum": [
             "open",
             "closed"
           ]
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "location": {
           "type": "array",
@@ -1730,6 +2312,36 @@
             ]
           }
         },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "value_of_funding": {
           "type": "array",
           "items": {
@@ -1803,12 +2415,57 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "report_type": {
           "type": "string",
@@ -1819,6 +2476,12 @@
             "overseas-report",
             "discontinued-investigation"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "vessel_type": {
           "type": "array",
@@ -1852,8 +2515,29 @@
             "company-led-drugs"
           ]
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "issued_date": {
           "type": "string",
@@ -1887,6 +2571,36 @@
               "urology",
               "vascular-cardiac-surgery"
             ]
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -1982,12 +2696,45 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "railway_type": {
           "type": "array",
@@ -2001,6 +2748,18 @@
             ]
           }
         },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "report_type": {
           "type": "string",
           "enum": [
@@ -2010,6 +2769,12 @@
             "discontinuation-report",
             "safety-digest"
           ]
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2045,11 +2810,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2148,12 +2964,63 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "assessment_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "bulk_published": {
           "type": "boolean"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2161,9 +3028,60 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "laid_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "sift_end_date": {
           "type": "string",
@@ -2214,11 +3132,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2251,11 +3220,62 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "bulk_published": {
           "type": "boolean"
         },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "hidden_indexable_content": {
           "type": "string"
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_categories": {
           "type": "array",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -752,7 +752,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -765,6 +792,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -862,7 +862,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -875,6 +902,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -486,7 +486,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -499,6 +526,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -606,7 +606,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -619,6 +646,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -690,7 +690,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -703,6 +730,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -441,7 +441,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -454,6 +481,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -282,6 +282,9 @@
         },
         "step_by_step_nav": {
           "$ref": "#/definitions/step_by_step_nav"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -620,6 +623,94 @@
         },
         "type": {
           "type": "string"
+        }
+      }
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -294,6 +294,9 @@
         },
         "step_by_step_nav": {
           "$ref": "#/definitions/step_by_step_nav"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -685,6 +688,94 @@
         },
         "type": {
           "type": "string"
+        }
+      }
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -184,6 +184,9 @@
       "properties": {
         "step_by_step_nav": {
           "$ref": "#/definitions/step_by_step_nav"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -487,6 +490,94 @@
         },
         "type": {
           "type": "string"
+        }
+      }
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -341,6 +341,9 @@
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "transaction_start_link": {
           "description": "Link the Start button will lead the user to.",
           "type": "string",
@@ -607,6 +610,94 @@
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -391,6 +391,9 @@
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "transaction_start_link": {
           "description": "Link the Start button will lead the user to.",
           "type": "string",
@@ -710,6 +713,94 @@
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -197,6 +197,9 @@
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "transaction_start_link": {
           "description": "Link the Start button will lead the user to.",
           "type": "string",
@@ -428,6 +431,94 @@
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -416,6 +416,9 @@
         "summary": {
           "type": "string"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time"
@@ -674,6 +677,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -469,6 +469,9 @@
         "summary": {
           "$ref": "#/definitions/multiple_content_types"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time"
@@ -780,6 +783,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -269,6 +269,9 @@
         "summary": {
           "$ref": "#/definitions/multiple_content_types"
         },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time"
@@ -503,6 +506,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -321,6 +321,9 @@
         },
         "publishing_request_id": {
           "$ref": "#/definitions/publishing_request_id"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -552,6 +555,94 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -374,6 +374,9 @@
         },
         "publishing_request_id": {
           "$ref": "#/definitions/publishing_request_id"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -639,6 +642,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -174,6 +174,9 @@
         },
         "publishing_request_id": {
           "$ref": "#/definitions/publishing_request_id"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
@@ -362,6 +365,94 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -586,7 +586,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -599,6 +626,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -664,7 +664,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -677,6 +704,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -376,7 +376,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -389,6 +416,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -706,7 +706,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -719,6 +746,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -799,7 +799,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -812,6 +839,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -457,7 +457,34 @@
             "type": "string"
           }
         },
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doing_business_in_the_eu": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "employ_eu_citizens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intellectual_property": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "personal_data": {
           "type": "array",
           "items": {
             "type": "string"
@@ -470,6 +497,30 @@
           }
         },
         "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_sector_procurement": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "receiving_eu_funding": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regulations_and_standards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_business_area": {
           "type": "array",
           "items": {
             "type": "string"

--- a/formats/answer.jsonnet
+++ b/formats/answer.jsonnet
@@ -11,6 +11,9 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/guide.jsonnet
+++ b/formats/guide.jsonnet
@@ -16,6 +16,9 @@
           type: "boolean",
           description: "Hide guide elements if this guide is part of a step by step navigation"
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/hmrc_manual_section.jsonnet
+++ b/formats/hmrc_manual_section.jsonnet
@@ -27,6 +27,9 @@
         child_section_groups: {
           "$ref": "#/definitions/hmrc_manual_child_section_groups",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/html_publication.jsonnet
+++ b/formats/html_publication.jsonnet
@@ -36,6 +36,9 @@
           type: "string",
           description: "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/licence.jsonnet
+++ b/formats/licence.jsonnet
@@ -30,6 +30,9 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/local_transaction.jsonnet
+++ b/formats/local_transaction.jsonnet
@@ -54,6 +54,9 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/manual.jsonnet
+++ b/formats/manual.jsonnet
@@ -20,6 +20,9 @@
         organisations: {
           "$ref": "#/definitions/manual_organisations",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/manual_section.jsonnet
+++ b/formats/manual_section.jsonnet
@@ -22,6 +22,9 @@
         organisations: {
           "$ref": "#/definitions/manual_organisations",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/shared/definitions/_eu_exit_business_finder_metadata.jsonnet
+++ b/formats/shared/definitions/_eu_exit_business_finder_metadata.jsonnet
@@ -1,0 +1,53 @@
+{
+  appear_in_find_eu_exit_guidance_business_finder: {
+    type: "string",
+  },
+  doing_business_in_the_eu: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  employ_eu_citizens: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  intellectual_property: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  personal_data: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  public_sector_procurement: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  receiving_eu_funding: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  regulations_and_standards: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+  sector_business_area: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+  },
+}

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -94,7 +94,7 @@
   aaib_report_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -143,7 +143,7 @@
   asylum_support_decision_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -203,7 +203,7 @@
   business_finance_support_scheme_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -306,7 +306,7 @@
   cma_case_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -414,7 +414,7 @@
   dfid_research_output_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -694,7 +694,7 @@
   countryside_stewardship_grant_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -766,7 +766,7 @@
   drug_safety_update_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -810,7 +810,7 @@
   employment_appeal_tribunal_decision_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -845,7 +845,7 @@
   employment_tribunal_decision_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -874,7 +874,7 @@
   european_structural_investment_fund_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -943,7 +943,7 @@
   export_health_certificate_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       certificate_status: {
         type: "string",
         enum: [
@@ -1197,7 +1197,7 @@
   international_development_fund_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1469,7 +1469,7 @@
   maib_report_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1505,7 +1505,7 @@
   medical_safety_alert_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1557,7 +1557,7 @@
   raib_report_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1592,7 +1592,7 @@
   residential_property_tribunal_decision_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1669,7 +1669,7 @@
   service_standard_report_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1682,7 +1682,7 @@
   statutory_instrument_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       laid_date: {
         type: "string",
         pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
@@ -1735,7 +1735,7 @@
   tax_tribunal_decision_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },
@@ -1762,7 +1762,7 @@
   utaac_decision_metadata: {
     type: "object",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       bulk_published: {
         type: "boolean",
       },

--- a/formats/shared/definitions/email_alert.jsonnet
+++ b/formats/shared/definitions/email_alert.jsonnet
@@ -28,7 +28,7 @@
     type: "object",
     description: "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
     additionalProperties: false,
-    properties: {
+    properties: (import "_eu_exit_business_finder_metadata.jsonnet") + {
       browse_pages: {
         type: "array",
         items: {

--- a/formats/simple_smart_answer.jsonnet
+++ b/formats/simple_smart_answer.jsonnet
@@ -73,6 +73,9 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/step_by_step_nav.jsonnet
+++ b/formats/step_by_step_nav.jsonnet
@@ -17,7 +17,10 @@
       properties: {
         step_by_step_nav: {
           "$ref": "#/definitions/step_by_step_nav"
-        }
+        },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       }
     }
   }

--- a/formats/transaction.jsonnet
+++ b/formats/transaction.jsonnet
@@ -41,7 +41,10 @@
         },
         start_button_text: {
           "$ref": "#/definitions/start_button_text",
-        }
+        },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },

--- a/formats/travel_advice.jsonnet
+++ b/formats/travel_advice.jsonnet
@@ -56,6 +56,9 @@
         publishing_request_id: {
           "$ref": "#/definitions/publishing_request_id",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
     country: {

--- a/formats/travel_advice_index.jsonnet
+++ b/formats/travel_advice_index.jsonnet
@@ -17,6 +17,9 @@
         publishing_request_id: {
           "$ref": "#/definitions/publishing_request_id",
         },
+        tags: {
+          "$ref": "#/definitions/tags",
+        },
       },
     },
   },


### PR DESCRIPTION
Should match Rummager schema stuff:

- https://github.com/alphagov/rummager/blob/master/config/schema/field_definitions.json
- https://github.com/alphagov/rummager/search?q=appear_in_find_eu_exit_guidance_business_finder&unscoped_q=appear_in_find_eu_exit_guidance_business_finder

[Trello card](https://trello.com/c/Z3jG94IX/68-add-tags-to-the-content-items)