### PR TITLE
Add 'South West' to business finance support finder

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -581,6 +581,7 @@
               "northern-ireland",
               "scotland",
               "south-east",
+              "south-west",
               "wales",
               "west-midlands",
               "yorkshire-and-the-humber"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -636,6 +636,7 @@
               "northern-ireland",
               "scotland",
               "south-east",
+              "south-west",
               "wales",
               "west-midlands",
               "yorkshire-and-the-humber"

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -470,6 +470,7 @@
               "northern-ireland",
               "scotland",
               "south-east",
+              "south-west",
               "wales",
               "west-midlands",
               "yorkshire-and-the-humber"

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -271,6 +271,7 @@
             "northern-ireland",
             "scotland",
             "south-east",
+            "south-west",
             "wales",
             "west-midlands",
             "yorkshire-and-the-humber",


### PR DESCRIPTION
Adding a missing region.

Trello card: https://trello.com/c/d8vArNoY/354-add-south-west-region-to-finance-and-support-for-your-business-finder