### PR TITLE
Add flag for finder generic description

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -348,6 +348,9 @@
         "format_name": {
           "type": "string"
         },
+        "generic_description": {
+          "type": "boolean"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -407,6 +407,9 @@
         "format_name": {
           "type": "string"
         },
+        "generic_description": {
+          "type": "boolean"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -199,6 +199,9 @@
         "format_name": {
           "type": "string"
         },
+        "generic_description": {
+          "type": "boolean"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -25,6 +25,9 @@
             },
           ],
         },
+        generic_description: {
+          type: "boolean",
+        },
         document_noun: {
           "$ref": "#/definitions/finder_document_noun",
         },


### PR DESCRIPTION
This PR adds a new field to the finder format to allow for a flag. The flag determines whether the filter description at the top of a filtered finder displays a constructed sentence of all the selected filters, or a generic description.