### PR TITLE
Add default_news_image field to organisation schema

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -373,6 +373,9 @@
         "change_note": {
           "$ref": "#/definitions/change_note"
         },
+        "default_news_image": {
+          "$ref": "#/definitions/image"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -455,6 +455,9 @@
         "change_note": {
           "$ref": "#/definitions/change_note"
         },
+        "default_news_image": {
+          "$ref": "#/definitions/image"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -229,6 +229,9 @@
         "change_note": {
           "$ref": "#/definitions/change_note"
         },
+        "default_news_image": {
+          "$ref": "#/definitions/image"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },

--- a/examples/organisation/frontend/organisation.json
+++ b/examples/organisation/frontend/organisation.json
@@ -42,6 +42,10 @@
   "details": {
     "brand": "department-of-energy-climate-change",
     "foi_exempt": false,
+    "default_news_image": {
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/12345/dexeu.jpg",
+      "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/12345/dexeu-high-rest.jpg"
+    },
     "logo": {
       "formatted_title": "Department<br/>for Exiting the<br/>European Union",
       "crest": "single-identity"

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -353,6 +353,9 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        default_news_image: {
+          "$ref": "#/definitions/image",
+        },
       },
     },
   },


### PR DESCRIPTION
For https://trello.com/c/3aDALgY4/416-we-should-expose-default-organisation-images-to-the-publishing-api