### PR TITLE
Add has_brexit_update flag

### DIFF
--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -347,6 +347,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "has_brexit_update": {
+          "$ref": "#/definitions/has_brexit_update"
+        },
         "image": {
           "$ref": "#/definitions/image"
         },
@@ -478,6 +481,10 @@
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "has_brexit_update": {
+      "description": "Flag to indicate that content has been updated due to Brexit.",
+      "type": "boolean"
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -406,6 +406,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "has_brexit_update": {
+          "$ref": "#/definitions/has_brexit_update"
+        },
         "image": {
           "$ref": "#/definitions/image"
         },
@@ -550,6 +553,10 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "has_brexit_update": {
+      "description": "Flag to indicate that content has been updated due to Brexit.",
+      "type": "boolean"
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -218,6 +218,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "has_brexit_update": {
+          "$ref": "#/definitions/has_brexit_update"
+        },
         "image": {
           "$ref": "#/definitions/image"
         },
@@ -289,6 +292,10 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "has_brexit_update": {
+      "description": "Flag to indicate that content has been updated due to Brexit.",
+      "type": "boolean"
     },
     "image": {
       "type": "object",

--- a/examples/detailed_guide/frontend/political_detailed_guide.json
+++ b/examples/detailed_guide/frontend/political_detailed_guide.json
@@ -28,6 +28,7 @@
       "current": false
     },
     "political": true,
+    "has_brexit_update": true,
     "emphasised_organisations": [
       "d65d4203-01f5-4920-a3b1-f614bfd8e83e"
     ]

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -56,6 +56,9 @@
         national_applicability: {
           "$ref": "#/definitions/national_applicability",
         },
+        has_brexit_update: {
+          "$ref": "#/definitions/has_brexit_update",
+        },
       },
     },
   },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -319,4 +319,8 @@
     type: "string",
     format: "date-time",
   },
+  has_brexit_update: {
+    type: "boolean",
+    description: "Flag to indicate that content has been updated due to Brexit.",
+  },
 }


### PR DESCRIPTION
This enables a has_brexit_update flag on Whitehall documents to be
stored in the content store and displayed by government-frontend.

Pair effort with @oscarwyatt 