### PR TITLE
Fix the jsonnet mini_portile install issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GEM
       addressable (>= 2.4)
     jsonnet (0.3.0)
       mini_portile2 (>= 2.2.0)
-    method_source (0.9.0)
-    mini_portile2 (2.3.0)
+    method_source (0.9.2)
+    mini_portile2 (2.4.0)
     mustermann (1.0.3)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.6.0)
@@ -28,25 +28,25 @@ GEM
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
     rake (12.3.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
       rack-protection (= 2.0.4)
       tilt (~> 2.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -65,4 +65,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,6 @@ node {
     }
 
     stage("bundle install") {
-      env.JSONNET_USE_SYSTEM_LIBRARIES = 1
       govuk.bundleApp();
     }
 


### PR DESCRIPTION
We've had issues installing jsonnet gem for a while due to problems with mini_portile: https://github.com/flavorjones/mini_portile/pull/86 which we patched with https://github.com/alphagov/govuk-content-schemas/pull/824

This updates the gems so we have the new mini_portile 2.4 with the fix and can undo our patch.