### PR TITLE
Add "all" part of taxonomy tree to filters

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -466,6 +466,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "all_part_of_taxonomy_tree": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "appear_in_find_eu_exit_guidance_business_finder": {
           "type": "string"
         },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -525,6 +525,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "all_part_of_taxonomy_tree": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "appear_in_find_eu_exit_guidance_business_finder": {
           "type": "string"
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -317,6 +317,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "all_part_of_taxonomy_tree": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "appear_in_find_eu_exit_guidance_business_finder": {
           "type": "string"
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -42,6 +42,12 @@
     type: "object",
     additionalProperties: false,
     properties: {
+      all_part_of_taxonomy_tree: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       appear_in_find_eu_exit_guidance_business_finder: {
         type: "string",
       },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -42,7 +42,7 @@
     type: "object",
     additionalProperties: false,
     properties: {
-      document_type: {
+      appear_in_find_eu_exit_guidance_business_finder: {
         type: "string",
       },
       content_purpose_supergroup: {
@@ -51,11 +51,17 @@
           type: "string",
         },
       },
+      document_type: {
+        type: "string",
+      },
       email_document_supertype: {
         type: "array",
         items: {
           type: "string",
         },
+      },
+      format: {
+        type: "string",
       },
       organisations: {
         type: "array",
@@ -68,12 +74,6 @@
         items: {
           type: "string",
         },
-      },
-      format: {
-        type: "string",
-      },
-      appear_in_find_eu_exit_guidance_business_finder: {
-        type: "string",
       },
     },
   },


### PR DESCRIPTION
This allows us to set one or more taxonomy topics as a base filter.  The `all` prefix means that they would potentially then be used in an `AND` style query with another taxonomy topic.

We only need it for one topic at the moment, but it'd be tricky to expand later so we'll start with allowing more than one.

I sorted the list of filters in the first commit, as it's getting longer than it was.  A-Z is hopefully easier to read.  It doesn't change the generated output.

I don't see the need for this in the reject list yet.