### PR TITLE
Add 'operator_between_facets' field

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -354,6 +354,15 @@
         "logo_path": {
           "type": "string"
         },
+        "operator_between_facets": {
+          "description": "Whether to perform an OR or an AND operation between facets when filtering the content.",
+          "type": "string",
+          "default": "and",
+          "enum": [
+            "and",
+            "or"
+          ]
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -413,6 +413,15 @@
         "logo_path": {
           "type": "string"
         },
+        "operator_between_facets": {
+          "description": "Whether to perform an OR or an AND operation between facets when filtering the content.",
+          "type": "string",
+          "default": "and",
+          "enum": [
+            "and",
+            "or"
+          ]
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -205,6 +205,15 @@
         "logo_path": {
           "type": "string"
         },
+        "operator_between_facets": {
+          "description": "Whether to perform an OR or an AND operation between facets when filtering the content.",
+          "type": "string",
+          "default": "and",
+          "enum": [
+            "and",
+            "or"
+          ]
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -49,6 +49,12 @@
         reject: {
           "$ref": "#/definitions/finder_reject_filter",
         },
+        operator_between_facets: {
+          type: "string",
+          enum: ["and", "or"],
+          default: "and",
+          description: "Whether to perform an OR or an AND operation between facets when filtering the content.",
+        },
         facets: {
           "$ref": "#/definitions/finder_facets",
         },


### PR DESCRIPTION
This will be used to perform an OR operation between facets of a finder, compared to the current default of an AND.

[Trello Card](https://trello.com/c/HoWR8kQM/150-or-between-and-in-facets-in-the-finder)