### PR TITLE
Add a "combine_mode" to finder facets

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -354,15 +354,6 @@
         "logo_path": {
           "type": "string"
         },
-        "operator_between_facets": {
-          "description": "Whether to perform an OR or an AND operation between facets when filtering the content.",
-          "type": "string",
-          "default": "and",
-          "enum": [
-            "and",
-            "or"
-          ]
-        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },
@@ -425,6 +416,15 @@
           "closed_value": {
             "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
             "$ref": "#/definitions/label_value_pair"
+          },
+          "combine_mode": {
+            "description": "Specifies how to combine with other facets",
+            "type": "string",
+            "default": "and",
+            "enum": [
+              "and",
+              "or"
+            ]
           },
           "display_as_result_metadata": {
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -413,15 +413,6 @@
         "logo_path": {
           "type": "string"
         },
-        "operator_between_facets": {
-          "description": "Whether to perform an OR or an AND operation between facets when filtering the content.",
-          "type": "string",
-          "default": "and",
-          "enum": [
-            "and",
-            "or"
-          ]
-        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },
@@ -484,6 +475,15 @@
           "closed_value": {
             "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
             "$ref": "#/definitions/label_value_pair"
+          },
+          "combine_mode": {
+            "description": "Specifies how to combine with other facets",
+            "type": "string",
+            "default": "and",
+            "enum": [
+              "and",
+              "or"
+            ]
           },
           "display_as_result_metadata": {
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -205,15 +205,6 @@
         "logo_path": {
           "type": "string"
         },
-        "operator_between_facets": {
-          "description": "Whether to perform an OR or an AND operation between facets when filtering the content.",
-          "type": "string",
-          "default": "and",
-          "enum": [
-            "and",
-            "or"
-          ]
-        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },
@@ -276,6 +267,15 @@
           "closed_value": {
             "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
             "$ref": "#/definitions/label_value_pair"
+          },
+          "combine_mode": {
+            "description": "Specifies how to combine with other facets",
+            "type": "string",
+            "default": "and",
+            "enum": [
+              "and",
+              "or"
+            ]
           },
           "display_as_result_metadata": {
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -49,12 +49,6 @@
         reject: {
           "$ref": "#/definitions/finder_reject_filter",
         },
-        operator_between_facets: {
-          type: "string",
-          enum: ["and", "or"],
-          default: "and",
-          description: "Whether to perform an OR or an AND operation between facets when filtering the content.",
-        },
         facets: {
           "$ref": "#/definitions/finder_facets",
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -172,6 +172,15 @@
           description: "Value that determines the closed state (the key field is in the past) of a topical facet.",
           "$ref": "#/definitions/label_value_pair",
         },
+        combine_mode: {
+          description: "Specifies how to combine with other facets",
+          type: "string",
+          enum: [
+            "and",
+            "or",
+          ],
+          default: "and",
+        },
       },
     },
   },


### PR DESCRIPTION
Say you have a business in the agriculture sector, and you export to
the EU.  If "sector" and "exporting" are facets, then the current AND
combining works:

    sector && exporting

If you also employ EU citizens, and that's a new facet, then you get
this situation:

    sector && exporting && employing

Which is unlikely to return what you want.  Why would a document be
tagged to all three?

What you actually want is something like this:

    sector && (exporting || employing)

This PR adds a field to each facet to say how to combine it.  The
field is optional.

This replaces PR #847 with a more generic solution.

---

[Trello card](https://trello.com/c/HoWR8kQM/150-or-between-and-in-facets-in-the-finder)