### PR TITLE
Add content store document types to finder filters

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -490,6 +490,12 @@
             "type": "string"
           }
         },
+        "content_store_document_type": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },
@@ -522,6 +528,12 @@
       "additionalProperties": false,
       "properties": {
         "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "content_store_document_type": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -549,6 +549,12 @@
             "type": "string"
           }
         },
+        "content_store_document_type": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },
@@ -581,6 +587,12 @@
       "additionalProperties": false,
       "properties": {
         "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "content_store_document_type": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -341,6 +341,12 @@
             "type": "string"
           }
         },
+        "content_store_document_type": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },
@@ -373,6 +379,12 @@
       "additionalProperties": false,
       "properties": {
         "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "content_store_document_type": {
           "type": "array",
           "items": {
             "type": "string"

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -57,6 +57,12 @@
           type: "string",
         },
       },
+      content_store_document_type: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       document_type: {
         type: "string",
       },
@@ -89,6 +95,12 @@
     additionalProperties: false,
     properties: {
       content_purpose_supergroup: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+      content_store_document_type: {
         type: "array",
         items: {
           type: "string",


### PR DESCRIPTION
We need to use them in citizen finders

https://trello.com/c/UDfCG0jA/184-add-foreign-travel-advice-index-to-going-abroad-finder