### PR TITLE
Add suggested ordered related items

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/calendar/publisher_v2/links.json
+++ b/dist/formats/calendar/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -128,6 +128,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -225,6 +229,10 @@
           "maxItems": 1
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -55,6 +55,10 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -140,6 +140,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -160,6 +160,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -67,6 +67,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -128,6 +128,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -222,6 +226,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -55,6 +55,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -147,6 +147,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -167,6 +167,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -239,6 +243,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -55,6 +55,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -135,6 +135,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -155,6 +155,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -232,6 +236,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -61,6 +61,10 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -134,6 +134,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -154,6 +154,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -233,6 +237,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -64,6 +64,10 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -141,6 +141,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -161,6 +161,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -246,6 +250,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -68,6 +68,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -131,6 +131,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -151,6 +151,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -228,6 +232,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -61,6 +61,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -127,6 +127,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -147,6 +147,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -217,6 +221,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -54,6 +54,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -287,6 +287,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -307,6 +307,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -376,6 +380,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -287,6 +287,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -307,6 +307,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -376,6 +380,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -122,6 +122,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -142,6 +142,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -208,6 +212,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -241,6 +245,10 @@
         },
         "second_level_browse_pages": {
           "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -126,6 +126,10 @@
         "sections": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -146,6 +146,10 @@
         "sections": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -219,6 +223,10 @@
           "maxItems": 1
         },
         "sections": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -57,6 +57,10 @@
         "sections": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -126,6 +126,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -146,6 +146,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -220,6 +224,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -57,6 +57,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -143,6 +143,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -163,6 +163,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -258,6 +262,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -67,6 +67,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -177,6 +177,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -278,6 +282,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/organisation/publisher_v2/links.json
+++ b/dist/formats/organisation/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -133,6 +133,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -153,6 +153,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -230,6 +234,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/person/publisher_v2/links.json
+++ b/dist/formats/person/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -291,6 +291,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -311,6 +311,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -384,6 +388,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -159,6 +159,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -179,6 +179,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -267,6 +271,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -70,6 +70,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -168,6 +168,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -249,6 +253,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/role/publisher_v2/links.json
+++ b/dist/formats/role/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -133,6 +133,10 @@
           "description": "The role that the relevant person is currently appointed to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -153,6 +153,10 @@
           "description": "The role that the relevant person is currently appointed to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -229,6 +233,10 @@
         },
         "role": {
           "description": "The role that the relevant person is currently appointed to.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/role_appointment/publisher_v2/links.json
+++ b/dist/formats/role_appointment/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -133,6 +133,10 @@
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -153,6 +153,10 @@
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -229,6 +233,10 @@
         },
         "service_manual_topics": {
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -60,6 +60,10 @@
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -129,6 +129,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -149,6 +149,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -222,6 +226,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -56,6 +56,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -238,6 +242,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/dist/formats/service_sign_in/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -290,6 +290,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -310,6 +310,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -379,6 +383,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -168,6 +168,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -241,6 +245,10 @@
         },
         "primary_publishing_organisation": {
           "description": "The primary organisation for this document",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -148,6 +148,10 @@
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -168,6 +168,10 @@
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -263,6 +267,10 @@
           "description": "A speaker that has a GOV.UK profile",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -72,6 +72,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -128,6 +128,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -216,6 +220,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -50,6 +50,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -141,6 +141,10 @@
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -161,6 +161,10 @@
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -245,6 +249,10 @@
         },
         "root_taxon": {
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -129,6 +129,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -149,6 +149,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -222,6 +226,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -56,6 +56,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -128,6 +128,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -219,6 +223,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -55,6 +55,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -128,6 +128,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -219,6 +223,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -55,6 +55,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -129,6 +129,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -149,6 +149,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -222,6 +226,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -125,6 +125,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -223,6 +227,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -52,6 +52,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/examples/case_study/frontend/case_study.json
+++ b/examples/case_study/frontend/case_study.json
@@ -108,6 +108,23 @@
         "locale": "en",
         "document_type": "document_collection"
       }
+    ],
+    "ordered_related_items": [
+
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "api_path": "/api/content/government/news/a-record-year-for-culture-in-the-northern-powerhouse",
+        "base_path": "/government/news/a-record-year-for-culture-in-the-northern-powerhouse",
+        "content_id": "bd22b146-e0f3-4344-9979-e6d28d5437ca",
+        "description": "More than 5 million people enjoyed the government-sponsored museums and galleries in the Northern Powerhouse between April and October 2018.",
+        "document_type": "press_release",
+        "locale": "en",
+        "public_updated_at": "2018-12-28T01:57:33Z",
+        "schema_name": "news_article",
+        "title": "A record year for culture in the Northern Powerhouse",
+        "withdrawn": false
+      }
     ]
   }
 }

--- a/examples/transaction/frontend/apply-marine-licence.json
+++ b/examples/transaction/frontend/apply-marine-licence.json
@@ -144,6 +144,20 @@
         "web_url": "http://www.dev.gov.uk/disposal-of-dredged-material-at-sea"
       }
     ],
+    "suggested_ordered_related_items": [
+      {
+        "api_path": "/api/content/fishing-vessel-licence-under-10-metres",
+        "base_path": "/fishing-vessel-licence-under-10-metres",
+        "content_id": "f4dc89b9-1234-4af0-b59d-f4a631409c45",
+        "description": "Fishing vessel licence description",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2019-01-23T19:16:06Z",
+        "schema_name": "guide",
+        "title": "Get a fishing vessel licence: vessels 10 metres or under",
+        "withdrawn": false
+      }
+    ],
     "organisations": [
       {
         "analytics_identifier": "PB57",

--- a/formats/shared/base_links.jsonnet
+++ b/formats/shared/base_links.jsonnet
@@ -17,4 +17,5 @@
   },
   original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   lead_organisations: "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+  suggested_ordered_related_items: "New A/B test suggestions for related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
 }

--- a/formats/shared/base_links.jsonnet
+++ b/formats/shared/base_links.jsonnet
@@ -17,5 +17,5 @@
   },
   original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   lead_organisations: "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-  suggested_ordered_related_items: "New A/B test suggestions for related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+  suggested_ordered_related_items: "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
 }


### PR DESCRIPTION
This PR adds `suggested_ordered_related_items` to `links` for use in the upcoming Related Links A/B test. The `case_study` example for `frontend` is also updated, which will be used to test changes in _government_frontend_.

Trello: https://trello.com/c/byNrHEMw