### PR TITLE
Add finder properties required for new facets

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -401,6 +401,10 @@
             "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
             "type": "string"
           },
+          "filter_value": {
+            "description": "A preset filter value that is applied when a checkbox is selected",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"
@@ -408,6 +412,13 @@
           "key": {
             "description": "The rummager field name used for this facet.",
             "type": "string"
+          },
+          "keys": {
+            "description": "Field names used for the taxon drop down.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "name": {
             "description": "Label for the facet.",
@@ -428,10 +439,13 @@
             "description": "Defines the UI component and how the facet is queried from the search API",
             "type": "string",
             "enum": [
-              "text",
+              "autocomplete",
+              "checkbox",
               "date",
-              "topical",
-              "hidden"
+              "hidden",
+              "taxon",
+              "text",
+              "topical"
             ]
           }
         }

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -496,6 +496,10 @@
             "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
             "type": "string"
           },
+          "filter_value": {
+            "description": "A preset filter value that is applied when a checkbox is selected",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"
@@ -503,6 +507,13 @@
           "key": {
             "description": "The rummager field name used for this facet.",
             "type": "string"
+          },
+          "keys": {
+            "description": "Field names used for the taxon drop down.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "name": {
             "description": "Label for the facet.",
@@ -523,10 +534,13 @@
             "description": "Defines the UI component and how the facet is queried from the search API",
             "type": "string",
             "enum": [
-              "text",
+              "autocomplete",
+              "checkbox",
               "date",
-              "topical",
-              "hidden"
+              "hidden",
+              "taxon",
+              "text",
+              "topical"
             ]
           }
         }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -288,6 +288,10 @@
             "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
             "type": "string"
           },
+          "filter_value": {
+            "description": "A preset filter value that is applied when a checkbox is selected",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"
@@ -295,6 +299,13 @@
           "key": {
             "description": "The rummager field name used for this facet.",
             "type": "string"
+          },
+          "keys": {
+            "description": "Field names used for the taxon drop down.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "name": {
             "description": "Label for the facet.",
@@ -315,10 +326,13 @@
             "description": "Defines the UI component and how the facet is queried from the search API",
             "type": "string",
             "enum": [
-              "text",
+              "autocomplete",
+              "checkbox",
               "date",
-              "topical",
-              "hidden"
+              "hidden",
+              "taxon",
+              "text",
+              "topical"
             ]
           }
         }

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -136,9 +136,20 @@
           description: "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
           type: "string",
         },
+        filter_value: {
+          description: "A preset filter value that is applied when a checkbox is selected",
+          type: "string"
+        },
         key: {
           description: "The rummager field name used for this facet.",
           type: "string",
+        },
+        keys: {
+          description: "Field names used for the taxon drop down.",
+          type: "array",
+          items: {
+            type: "string",
+          },
         },
         filterable: {
           description: "This must be true to show the facet to users.",
@@ -163,10 +174,13 @@
           description: "Defines the UI component and how the facet is queried from the search API",
           type: "string",
           enum: [
-            "text",
+            "autocomplete",
+            "checkbox",
             "date",
-            "topical",
             "hidden",
+            "taxon",
+            "text",
+            "topical",
           ],
         },
         allowed_values: {


### PR DESCRIPTION
These are required for the checkbox facet (aka Show only Brexit) and the
cascading drop down (aka the taxons selector) to work.


https://trello.com/c/oE1sdBdt/278-add-ability-to-publish-news-and-communications-finder-from-rummager