### PR TITLE
Add special-route-publisher to publishing-app list

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -475,6 +475,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -597,6 +597,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -326,6 +326,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -445,6 +445,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -548,6 +548,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -277,6 +277,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -607,6 +607,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -719,6 +719,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -388,6 +388,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -448,6 +448,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -551,6 +551,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -280,6 +280,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -485,6 +485,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -588,6 +588,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -317,6 +317,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -667,6 +667,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -784,6 +784,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -545,6 +545,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -742,6 +742,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -861,6 +861,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -509,6 +509,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -559,6 +559,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -665,6 +665,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -429,6 +429,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -616,6 +616,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -728,6 +728,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -463,6 +463,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -543,6 +543,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -657,6 +657,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -415,6 +415,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -509,6 +509,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -612,6 +612,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -341,6 +341,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/external_content/notification/schema.json
+++ b/dist/formats/external_content/notification/schema.json
@@ -445,6 +445,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -270,6 +270,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -484,6 +484,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -604,6 +604,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -354,6 +354,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -767,6 +767,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -879,6 +879,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -594,6 +594,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -574,6 +574,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -679,6 +679,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -401,6 +401,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -600,6 +600,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -703,6 +703,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -432,6 +432,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -626,6 +626,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -729,6 +729,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -458,6 +458,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -398,6 +398,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -426,6 +426,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -271,6 +271,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -504,6 +504,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -626,6 +626,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -355,6 +355,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -475,6 +475,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -597,6 +597,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -326,6 +326,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -560,6 +560,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -663,6 +663,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -392,6 +392,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -564,6 +564,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -667,6 +667,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -396,6 +396,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -392,6 +392,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -449,6 +449,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -270,6 +270,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -470,6 +470,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -570,6 +570,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -320,6 +320,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -388,6 +388,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -434,6 +434,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -494,6 +494,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -616,6 +616,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -345,6 +345,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -518,6 +518,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -640,6 +640,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -369,6 +369,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -477,6 +477,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -589,6 +589,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -286,6 +286,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -554,6 +554,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -681,6 +681,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -404,6 +404,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -537,6 +537,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -664,6 +664,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -387,6 +387,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -505,6 +505,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -608,6 +608,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -337,6 +337,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -643,6 +643,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -773,6 +773,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -435,6 +435,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -1014,6 +1014,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -1149,6 +1149,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -780,6 +780,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -521,6 +521,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -624,6 +624,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -353,6 +353,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -515,6 +515,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -645,6 +645,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -366,6 +366,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -484,6 +484,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -606,6 +606,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -335,6 +335,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -736,6 +736,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -843,6 +843,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -568,6 +568,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -662,6 +662,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -785,6 +785,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -474,6 +474,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -371,6 +371,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -386,6 +386,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -257,6 +257,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -497,6 +497,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -641,6 +641,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -356,6 +356,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -457,6 +457,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -578,6 +578,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -296,6 +296,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -496,6 +496,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -607,6 +607,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -344,6 +344,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -438,6 +438,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -541,6 +541,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -270,6 +270,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -454,6 +454,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -561,6 +561,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -282,6 +282,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -487,6 +487,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -590,6 +590,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -319,6 +319,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -467,6 +467,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -575,6 +575,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -280,6 +280,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -529,6 +529,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -651,6 +651,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -380,6 +380,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -537,6 +537,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -659,6 +659,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -388,6 +388,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -573,6 +573,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -676,6 +676,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -426,6 +426,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2088,6 +2088,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2215,6 +2215,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1972,6 +1972,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -660,6 +660,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -789,6 +789,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -424,6 +424,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -504,6 +504,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -607,6 +607,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -369,6 +369,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -477,6 +477,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -579,6 +579,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -310,6 +310,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -450,6 +450,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -534,6 +534,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -347,6 +347,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -494,6 +494,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -597,6 +597,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -326,6 +326,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -465,6 +465,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -584,6 +584,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -289,6 +289,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -455,6 +455,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -555,6 +555,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -276,6 +276,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -452,6 +452,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -555,6 +555,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -284,6 +284,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -548,6 +548,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -670,6 +670,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -399,6 +399,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -584,6 +584,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -709,6 +709,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -432,6 +432,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -462,6 +462,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -568,6 +568,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -291,6 +291,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -461,6 +461,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -564,6 +564,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -293,6 +293,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -376,6 +376,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -448,6 +448,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -551,6 +551,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -280,6 +280,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -484,6 +484,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -601,6 +601,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -324,6 +324,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -614,6 +614,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -726,6 +726,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -395,6 +395,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
+        "special-route-publisher",
         "specialist-publisher",
         "static",
         "tariff",

--- a/formats/shared/definitions/publishing_app.jsonnet
+++ b/formats/shared/definitions/publishing_app.jsonnet
@@ -28,6 +28,7 @@
       "share-sale-publisher",
       "short-url-manager",
       "smartanswers",
+      "special-route-publisher",
       "specialist-publisher",
       "static",
       "tariff",


### PR DESCRIPTION
This PR adds the new special-route-publisher to the list of publishing apps. special-route-publisher is a rake task that publishes special routes on behalf to apps to the publishing-api.