### PR TITLE
Add content-store to list of rendering apps

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -506,6 +506,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -623,6 +623,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -341,6 +341,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -476,6 +476,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -574,6 +574,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -292,6 +292,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -638,6 +638,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -745,6 +745,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -403,6 +403,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -479,6 +479,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -577,6 +577,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -295,6 +295,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -516,6 +516,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -614,6 +614,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -332,6 +332,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -698,6 +698,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -810,6 +810,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -560,6 +560,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -773,6 +773,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -887,6 +887,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -524,6 +524,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -590,6 +590,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -691,6 +691,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -444,6 +444,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -647,6 +647,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -754,6 +754,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -478,6 +478,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -574,6 +574,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -683,6 +683,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -430,6 +430,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -540,6 +540,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -638,6 +638,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -356,6 +356,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -515,6 +515,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -630,6 +630,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -369,6 +369,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -798,6 +798,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -905,6 +905,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -609,6 +609,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -605,6 +605,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -705,6 +705,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -416,6 +416,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -631,6 +631,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -729,6 +729,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -447,6 +447,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -657,6 +657,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -755,6 +755,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -473,6 +473,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -535,6 +535,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -652,6 +652,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -370,6 +370,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -506,6 +506,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -623,6 +623,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -341,6 +341,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -591,6 +591,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -689,6 +689,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -407,6 +407,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -595,6 +595,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -693,6 +693,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -411,6 +411,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -423,6 +423,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -475,6 +475,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -285,6 +285,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -501,6 +501,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -596,6 +596,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -335,6 +335,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -419,6 +419,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -460,6 +460,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -281,6 +281,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -525,6 +525,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -642,6 +642,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -360,6 +360,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -549,6 +549,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -666,6 +666,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -384,6 +384,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -508,6 +508,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -615,6 +615,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -301,6 +301,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -585,6 +585,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -707,6 +707,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -419,6 +419,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -568,6 +568,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -690,6 +690,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -402,6 +402,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -536,6 +536,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -634,6 +634,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -352,6 +352,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -674,6 +674,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -799,6 +799,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -450,6 +450,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -1045,6 +1045,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -1175,6 +1175,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -795,6 +795,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -552,6 +552,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -650,6 +650,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -368,6 +368,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -546,6 +546,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -671,6 +671,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -381,6 +381,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -515,6 +515,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -632,6 +632,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -350,6 +350,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -767,6 +767,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -869,6 +869,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -583,6 +583,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -693,6 +693,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -811,6 +811,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -489,6 +489,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -528,6 +528,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -667,6 +667,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -371,6 +371,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -488,6 +488,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -604,6 +604,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -311,6 +311,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -527,6 +527,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -633,6 +633,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -359,6 +359,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -469,6 +469,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -567,6 +567,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -285,6 +285,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -485,6 +485,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -587,6 +587,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -297,6 +297,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -518,6 +518,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -616,6 +616,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -334,6 +334,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -498,6 +498,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -601,6 +601,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -295,6 +295,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -560,6 +560,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -677,6 +677,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -395,6 +395,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -568,6 +568,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -685,6 +685,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -403,6 +403,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -604,6 +604,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -702,6 +702,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -441,6 +441,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2154,6 +2154,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2276,6 +2276,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2022,6 +2022,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -691,6 +691,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -815,6 +815,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -439,6 +439,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -535,6 +535,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -633,6 +633,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -384,6 +384,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -508,6 +508,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -605,6 +605,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -325,6 +325,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -481,6 +481,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -560,6 +560,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -362,6 +362,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -525,6 +525,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -623,6 +623,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -341,6 +341,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -496,6 +496,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -610,6 +610,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -304,6 +304,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -486,6 +486,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -581,6 +581,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -291,6 +291,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -483,6 +483,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -581,6 +581,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -299,6 +299,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -579,6 +579,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -696,6 +696,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -414,6 +414,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -615,6 +615,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -735,6 +735,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -458,6 +458,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -493,6 +493,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -594,6 +594,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -317,6 +317,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -492,6 +492,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -590,6 +590,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -308,6 +308,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -479,6 +479,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -577,6 +577,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -295,6 +295,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -515,6 +515,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -627,6 +627,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -339,6 +339,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -645,6 +645,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -752,6 +752,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -410,6 +410,7 @@
         "calculators",
         "calendars",
         "collections",
+        "content-store",
         "email-alert-frontend",
         "email-campaign-frontend",
         "feedback",

--- a/formats/shared/definitions/rendering_app.jsonnet
+++ b/formats/shared/definitions/rendering_app.jsonnet
@@ -6,6 +6,7 @@
       "calculators",
       "calendars",
       "collections",
+      "content-store",
       "email-alert-frontend",
       "email-campaign-frontend",
       "feedback",


### PR DESCRIPTION
This PR adds content-store to the list of rendering apps. content-store will render the `/api/content` special route.