### PR TITLE
Allow finder email signup extensions

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -267,92 +267,81 @@
       ]
     },
     "details": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "email_signup_choice",
-            "email_filter_by",
-            "subscription_list_title_prefix"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "beta": {
-              "$ref": "#/definitions/finder_beta"
+      "type": "object",
+      "required": [
+        "subscription_list_title_prefix"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "beta": {
+          "$ref": "#/definitions/finder_beta"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email_filter_by": {
+          "oneOf": [
+            {
+              "type": "string"
             },
-            "change_history": {
-              "$ref": "#/definitions/change_history"
-            },
-            "email_filter_by": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "email_filter_name": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/facet_name"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "email_signup_choice": {
-              "$ref": "#/definitions/facet_choices"
-            },
-            "subscription_list_title_prefix": {
-              "$ref": "#/definitions/subscription_list_title_prefix"
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_filter_facets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "facet_id",
+              "facet_name"
+            ],
+            "properties": {
+              "facet_choices": {
+                "$ref": "#/definitions/facet_choices"
+              },
+              "facet_id": {
+                "type": "string"
+              },
+              "facet_name": {
+                "$ref": "#/definitions/facet_name"
+              },
+              "filter_key": {
+                "type": "string"
+              },
+              "filter_value": {
+                "type": "string"
+              }
             }
           }
         },
-        {
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/facet_name"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_signup_choice": {
+          "$ref": "#/definitions/facet_choices"
+        },
+        "filter": {
           "type": "object",
-          "required": [
-            "email_filter_facets",
-            "subscription_list_title_prefix"
-          ],
           "additionalProperties": false,
           "properties": {
-            "beta": {
-              "$ref": "#/definitions/finder_beta"
-            },
-            "change_history": {
-              "$ref": "#/definitions/change_history"
-            },
-            "email_filter_facets": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "facet_id",
-                  "facet_name",
-                  "facet_choices"
-                ],
-                "properties": {
-                  "facet_choices": {
-                    "$ref": "#/definitions/facet_choices"
-                  },
-                  "facet_id": {
-                    "type": "string"
-                  },
-                  "facet_name": {
-                    "$ref": "#/definitions/facet_name"
-                  }
-                }
-              }
-            },
-            "subscription_list_title_prefix": {
-              "$ref": "#/definitions/subscription_list_title_prefix"
+            "content_purpose_supergroup": {
+              "type": "string"
             }
           }
+        },
+        "subscription_list_title_prefix": {
+          "$ref": "#/definitions/subscription_list_title_prefix"
         }
-      ]
+      }
     },
     "facet_choices": {
       "type": "array",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -355,92 +355,81 @@
       ]
     },
     "details": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "email_signup_choice",
-            "email_filter_by",
-            "subscription_list_title_prefix"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "beta": {
-              "$ref": "#/definitions/finder_beta"
+      "type": "object",
+      "required": [
+        "subscription_list_title_prefix"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "beta": {
+          "$ref": "#/definitions/finder_beta"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email_filter_by": {
+          "oneOf": [
+            {
+              "type": "string"
             },
-            "change_history": {
-              "$ref": "#/definitions/change_history"
-            },
-            "email_filter_by": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "email_filter_name": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/facet_name"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "email_signup_choice": {
-              "$ref": "#/definitions/facet_choices"
-            },
-            "subscription_list_title_prefix": {
-              "$ref": "#/definitions/subscription_list_title_prefix"
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_filter_facets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "facet_id",
+              "facet_name"
+            ],
+            "properties": {
+              "facet_choices": {
+                "$ref": "#/definitions/facet_choices"
+              },
+              "facet_id": {
+                "type": "string"
+              },
+              "facet_name": {
+                "$ref": "#/definitions/facet_name"
+              },
+              "filter_key": {
+                "type": "string"
+              },
+              "filter_value": {
+                "type": "string"
+              }
             }
           }
         },
-        {
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/facet_name"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_signup_choice": {
+          "$ref": "#/definitions/facet_choices"
+        },
+        "filter": {
           "type": "object",
-          "required": [
-            "email_filter_facets",
-            "subscription_list_title_prefix"
-          ],
           "additionalProperties": false,
           "properties": {
-            "beta": {
-              "$ref": "#/definitions/finder_beta"
-            },
-            "change_history": {
-              "$ref": "#/definitions/change_history"
-            },
-            "email_filter_facets": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "facet_id",
-                  "facet_name",
-                  "facet_choices"
-                ],
-                "properties": {
-                  "facet_choices": {
-                    "$ref": "#/definitions/facet_choices"
-                  },
-                  "facet_id": {
-                    "type": "string"
-                  },
-                  "facet_name": {
-                    "$ref": "#/definitions/facet_name"
-                  }
-                }
-              }
-            },
-            "subscription_list_title_prefix": {
-              "$ref": "#/definitions/subscription_list_title_prefix"
+            "content_purpose_supergroup": {
+              "type": "string"
             }
           }
+        },
+        "subscription_list_title_prefix": {
+          "$ref": "#/definitions/subscription_list_title_prefix"
         }
-      ]
+      }
     },
     "facet_choices": {
       "type": "array",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -160,86 +160,78 @@
       ]
     },
     "details": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "email_signup_choice",
-            "email_filter_by",
-            "subscription_list_title_prefix"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "beta": {
-              "$ref": "#/definitions/finder_beta"
+      "type": "object",
+      "required": [
+        "subscription_list_title_prefix"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "beta": {
+          "$ref": "#/definitions/finder_beta"
+        },
+        "email_filter_by": {
+          "oneOf": [
+            {
+              "type": "string"
             },
-            "email_filter_by": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "email_filter_name": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/facet_name"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "email_signup_choice": {
-              "$ref": "#/definitions/facet_choices"
-            },
-            "subscription_list_title_prefix": {
-              "$ref": "#/definitions/subscription_list_title_prefix"
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_filter_facets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "facet_id",
+              "facet_name"
+            ],
+            "properties": {
+              "facet_choices": {
+                "$ref": "#/definitions/facet_choices"
+              },
+              "facet_id": {
+                "type": "string"
+              },
+              "facet_name": {
+                "$ref": "#/definitions/facet_name"
+              },
+              "filter_key": {
+                "type": "string"
+              },
+              "filter_value": {
+                "type": "string"
+              }
             }
           }
         },
-        {
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/facet_name"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_signup_choice": {
+          "$ref": "#/definitions/facet_choices"
+        },
+        "filter": {
           "type": "object",
-          "required": [
-            "email_filter_facets",
-            "subscription_list_title_prefix"
-          ],
           "additionalProperties": false,
           "properties": {
-            "beta": {
-              "$ref": "#/definitions/finder_beta"
-            },
-            "email_filter_facets": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "facet_id",
-                  "facet_name",
-                  "facet_choices"
-                ],
-                "properties": {
-                  "facet_choices": {
-                    "$ref": "#/definitions/facet_choices"
-                  },
-                  "facet_id": {
-                    "type": "string"
-                  },
-                  "facet_name": {
-                    "$ref": "#/definitions/facet_name"
-                  }
-                }
-              }
-            },
-            "subscription_list_title_prefix": {
-              "$ref": "#/definitions/subscription_list_title_prefix"
+            "content_purpose_supergroup": {
+              "type": "string"
             }
           }
+        },
+        "subscription_list_title_prefix": {
+          "$ref": "#/definitions/subscription_list_title_prefix"
         }
-      ]
+      }
     },
     "facet_choices": {
       "type": "array",

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -66,88 +66,79 @@
         },
       },
     },
-
     details: {
-      oneOf: [
-        {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "email_signup_choice",
-            "email_filter_by",
-            "subscription_list_title_prefix",
-          ],
-          properties: {
-            beta: {
-              "$ref": "#/definitions/finder_beta",
-            },
-            email_signup_choice: {
-              "$ref": "#/definitions/facet_choices",
-            },
-            email_filter_name: {
-              oneOf: [
-                {
-                  "$ref": "#/definitions/facet_name"
-                },
-                {
-                  type: "null",
-                },
-              ]
-            },
-            email_filter_by: {
-              oneOf: [
-                {
-                  type: "string",
-                },
-                {
-                  type: "null",
-                },
-              ],
-            },
-            subscription_list_title_prefix: {
-              "$ref": "#/definitions/subscription_list_title_prefix",
-            },
-          }
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "subscription_list_title_prefix",
+      ],
+      properties: {
+        beta: {
+          "$ref": "#/definitions/finder_beta",
         },
-        {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "email_filter_facets",
-            "subscription_list_title_prefix",
-          ],
-          properties: {
-            beta: {
-              "$ref": "#/definitions/finder_beta",
+        email_signup_choice: {
+          "$ref": "#/definitions/facet_choices",
+        },
+        email_filter_name: {
+          oneOf: [
+            {
+              "$ref": "#/definitions/facet_name"
             },
-            email_filter_facets : {
-              type: "array",
-              items: {
-                type: "object",
-                required: [
-                  "facet_id",
-                  "facet_name",
-                  "facet_choices",
-                ],
-                properties: {
-                  facet_id: {
-                    type: "string",
-                  },
-                  facet_name: {
-                    "$ref": "#/definitions/facet_name"
-                  },
-                  facet_choices: {
-                    "$ref": "#/definitions/facet_choices",
-                  },
-                },
+            {
+              type: "null",
+            },
+          ]
+        },
+        email_filter_by: {
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+        email_filter_facets : {
+          type: "array",
+          items: {
+            type: "object",
+            required: [
+              "facet_id",
+              "facet_name",
+            ],
+            properties: {
+              facet_id: {
+                type: "string",
+              },
+              facet_name: {
+                "$ref": "#/definitions/facet_name"
+              },
+              facet_choices: {
+                "$ref": "#/definitions/facet_choices",
+              },
+              filter_key: {
+                type: "string",
+              },
+              filter_value: {
+                type: "string",
               },
             },
-            subscription_list_title_prefix: {
-              "$ref": "#/definitions/subscription_list_title_prefix",
-            },
-          }
+          },
         },
-      ],
+        subscription_list_title_prefix: {
+          "$ref": "#/definitions/subscription_list_title_prefix",
+        },
+        filter: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            content_purpose_supergroup: {
+              type: "string",
+            },
+          },
+        },
+      },
     },
   },
   links: (import "shared/base_links.jsonnet") + {


### PR DESCRIPTION
https://trello.com/c/HZHHKXc8/311-make-it-possible-to-publish-news-and-communications-email-alert-content-item-from-rummager

This adds the details.filter attribute, so one can set default filters on an email signup, like on finders.

It also makes facet options optional, enabling us to set dynamic facets which don't have options hard coded into the email signup content item. One example of this is a people filter which is often changing.