### PR TITLE
Add reject.content_purpose_supergroup to email_signup

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -342,6 +342,15 @@
             }
           }
         },
+        "reject": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "content_purpose_supergroup": {
+              "type": "string"
+            }
+          }
+        },
         "subscription_list_title_prefix": {
           "$ref": "#/definitions/subscription_list_title_prefix"
         }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -434,6 +434,15 @@
             }
           }
         },
+        "reject": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "content_purpose_supergroup": {
+              "type": "string"
+            }
+          }
+        },
         "subscription_list_title_prefix": {
           "$ref": "#/definitions/subscription_list_title_prefix"
         }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -228,6 +228,15 @@
             }
           }
         },
+        "reject": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "content_purpose_supergroup": {
+              "type": "string"
+            }
+          }
+        },
         "subscription_list_title_prefix": {
           "$ref": "#/definitions/subscription_list_title_prefix"
         }

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -138,6 +138,15 @@
             },
           },
         },
+        reject: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            content_purpose_supergroup: {
+              type: "string",
+            },
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
https://trello.com/c/ylw7DDQa/329-enable-email-alert-api-to-reject-a-content-purpose-supergroup

This enables use to reject a content purpose supergroup on email signup
pages. This is similar to the finder content items.

Blocks https://github.com/alphagov/rummager/pull/1422