### PR TITLE
Remove publicapi rendering app

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -521,7 +521,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -642,7 +642,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -352,7 +352,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -491,7 +491,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -593,7 +593,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -303,7 +303,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -653,7 +653,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -764,7 +764,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -414,7 +414,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -494,7 +494,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -596,7 +596,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -306,7 +306,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -531,7 +531,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -633,7 +633,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -343,7 +343,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -713,7 +713,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -829,7 +829,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -571,7 +571,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -788,7 +788,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -906,7 +906,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -535,7 +535,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -605,7 +605,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -710,7 +710,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -455,7 +455,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -662,7 +662,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -773,7 +773,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -489,7 +489,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -589,7 +589,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -702,7 +702,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -441,7 +441,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -555,7 +555,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -657,7 +657,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -367,7 +367,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -530,7 +530,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -649,7 +649,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -380,7 +380,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -813,7 +813,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -924,7 +924,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -620,7 +620,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -618,7 +618,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -722,7 +722,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -428,7 +428,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -646,7 +646,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -748,7 +748,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -458,7 +458,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -672,7 +672,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -774,7 +774,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -484,7 +484,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -550,7 +550,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -671,7 +671,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -381,7 +381,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -521,7 +521,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -642,7 +642,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -352,7 +352,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -606,7 +606,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -708,7 +708,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -418,7 +418,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -610,7 +610,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -712,7 +712,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -422,7 +422,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -434,7 +434,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -486,7 +486,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -296,7 +296,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -516,7 +516,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -615,7 +615,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -346,7 +346,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -430,7 +430,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -471,7 +471,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -292,7 +292,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -540,7 +540,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -661,7 +661,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -371,7 +371,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -564,7 +564,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -685,7 +685,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -395,7 +395,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -523,7 +523,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -634,7 +634,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -312,7 +312,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -600,7 +600,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -726,7 +726,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -430,7 +430,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -583,7 +583,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -709,7 +709,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -413,7 +413,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -551,7 +551,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -653,7 +653,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -363,7 +363,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -689,7 +689,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -818,7 +818,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -461,7 +461,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -1060,7 +1060,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -1194,7 +1194,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -806,7 +806,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -567,7 +567,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -669,7 +669,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -379,7 +379,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -561,7 +561,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -690,7 +690,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -392,7 +392,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -530,7 +530,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -651,7 +651,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -361,7 +361,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -782,7 +782,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -888,7 +888,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -594,7 +594,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -708,7 +708,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -830,7 +830,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -500,7 +500,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -543,7 +543,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -686,7 +686,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -382,7 +382,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -503,7 +503,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -623,7 +623,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -322,7 +322,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -542,7 +542,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -652,7 +652,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -370,7 +370,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -484,7 +484,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -586,7 +586,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -296,7 +296,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -500,7 +500,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -606,7 +606,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -308,7 +308,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -533,7 +533,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -635,7 +635,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -345,7 +345,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -513,7 +513,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -620,7 +620,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -306,7 +306,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -575,7 +575,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -696,7 +696,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -406,7 +406,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -583,7 +583,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -704,7 +704,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -414,7 +414,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -619,7 +619,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -721,7 +721,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -452,7 +452,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2169,7 +2169,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2295,7 +2295,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2033,7 +2033,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -706,7 +706,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -834,7 +834,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -450,7 +450,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -550,7 +550,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -652,7 +652,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -395,7 +395,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -523,7 +523,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -624,7 +624,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -336,7 +336,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -492,7 +492,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -571,7 +571,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -373,7 +373,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -540,7 +540,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -642,7 +642,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -352,7 +352,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -511,7 +511,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -629,7 +629,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -315,7 +315,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -501,7 +501,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -600,7 +600,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -302,7 +302,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -498,7 +498,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -600,7 +600,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -310,7 +310,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -594,7 +594,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -715,7 +715,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -425,7 +425,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -630,7 +630,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -754,7 +754,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -469,7 +469,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -508,7 +508,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -613,7 +613,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -328,7 +328,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -507,7 +507,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -609,7 +609,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -319,7 +319,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -494,7 +494,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -596,7 +596,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -306,7 +306,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -530,7 +530,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -646,7 +646,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -350,7 +350,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -660,7 +660,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -771,7 +771,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -421,7 +421,6 @@
         "licencefinder",
         "manuals-frontend",
         "performanceplatform-big-screen-view",
-        "publicapi",
         "rummager",
         "search-api",
         "service-manual-frontend",

--- a/formats/shared/definitions/rendering_app.jsonnet
+++ b/formats/shared/definitions/rendering_app.jsonnet
@@ -17,7 +17,6 @@
       "licencefinder",
       "manuals-frontend",
       "performanceplatform-big-screen-view",
-      "publicapi",
       "rummager",
       "search-api",
       "service-manual-frontend",


### PR DESCRIPTION
This PR removes the publicapi rendering app, since the app no longer exists.