### PR TITLE
Add recent finder-frontend schema changes

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -413,6 +413,10 @@
             "description": "This must be true to show the facet to users.",
             "type": "boolean"
           },
+          "hide_facet_tag": {
+            "description": "Causes the facet to not have a facet tag shown in a finder",
+            "type": "boolean"
+          },
           "key": {
             "description": "The rummager field name used for this facet.",
             "type": "string"
@@ -431,6 +435,19 @@
           "open_value": {
             "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
             "$ref": "#/definitions/label_value_pair"
+          },
+          "option_lookup": {
+            "description": "A map of keys to values that can be used to associate allowed_values with multiple values",
+            "type": "object",
+            "additionalProperties": true,
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "preposition": {
             "description": "Text used to augment the description of the search when the facet is used.",
@@ -451,6 +468,7 @@
               "checkbox",
               "date",
               "hidden",
+              "radio",
               "taxon",
               "text",
               "topical"
@@ -676,6 +694,10 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "default": {
+          "description": "The default option for a radio facet",
+          "type": "boolean"
+        },
         "label": {
           "description": "A human readable label",
           "type": "string"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -512,6 +512,10 @@
             "description": "This must be true to show the facet to users.",
             "type": "boolean"
           },
+          "hide_facet_tag": {
+            "description": "Causes the facet to not have a facet tag shown in a finder",
+            "type": "boolean"
+          },
           "key": {
             "description": "The rummager field name used for this facet.",
             "type": "string"
@@ -530,6 +534,19 @@
           "open_value": {
             "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
             "$ref": "#/definitions/label_value_pair"
+          },
+          "option_lookup": {
+            "description": "A map of keys to values that can be used to associate allowed_values with multiple values",
+            "type": "object",
+            "additionalProperties": true,
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "preposition": {
             "description": "Text used to augment the description of the search when the facet is used.",
@@ -550,6 +567,7 @@
               "checkbox",
               "date",
               "hidden",
+              "radio",
               "taxon",
               "text",
               "topical"
@@ -788,6 +806,10 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "default": {
+          "description": "The default option for a radio facet",
+          "type": "boolean"
+        },
         "label": {
           "description": "A human readable label",
           "type": "string"

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -296,6 +296,10 @@
             "description": "This must be true to show the facet to users.",
             "type": "boolean"
           },
+          "hide_facet_tag": {
+            "description": "Causes the facet to not have a facet tag shown in a finder",
+            "type": "boolean"
+          },
           "key": {
             "description": "The rummager field name used for this facet.",
             "type": "string"
@@ -314,6 +318,19 @@
           "open_value": {
             "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
             "$ref": "#/definitions/label_value_pair"
+          },
+          "option_lookup": {
+            "description": "A map of keys to values that can be used to associate allowed_values with multiple values",
+            "type": "object",
+            "additionalProperties": true,
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "preposition": {
             "description": "Text used to augment the description of the search when the facet is used.",
@@ -334,6 +351,7 @@
               "checkbox",
               "date",
               "hidden",
+              "radio",
               "taxon",
               "text",
               "topical"
@@ -499,6 +517,10 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "default": {
+          "description": "The default option for a radio facet",
+          "type": "boolean"
+        },
         "label": {
           "description": "A human readable label",
           "type": "string"

--- a/examples/finder/frontend/statistics.json
+++ b/examples/finder/frontend/statistics.json
@@ -1,0 +1,173 @@
+{
+  "content_id": "8f827d53-9ad1-4b90-b6ae-2301c1ecdf02",
+  "base_path": "/statistics",
+  "title": "Statistics",
+  "description": "Find statistics from government",
+  "locale": "en",
+  "updated_at": "2019-01-15T14:47:48.000+00:00",
+  "public_updated_at": "2019-01-15T14:47:48.000+00:00",
+  "schema_name": "finder",
+  "document_type": "finder",
+  "details": {
+    "document_noun": "statistic",
+    "filter": {
+      "content_store_document_type": [
+        "statistics",
+        "national_statistics",
+        "statistical_data_set",
+        "official_statistics"
+      ]
+    },
+    "format_name": "statistic",
+    "show_summaries": true,
+    "sort": [
+      {
+        "name": "Most viewed",
+        "key": "-popularity"
+      },
+      {
+        "name": "Relevance",
+        "key": "-relevance"
+      },
+      {
+        "name": "Updated (newest)",
+        "key": "-public_timestamp",
+        "default": true
+      },
+      {
+        "name": "Updated (oldest)",
+        "key": "public_timestamp"
+      },
+      {
+        "name": "Release date (latest)",
+        "key": "-release_timestamp"
+      },
+      {
+        "name": "Release date (oldest)",
+        "key": "release_timestamp"
+      }
+    ],
+    "facets": [
+      {
+        "key": "release_timestamp",
+        "name": "release_timestamp",
+        "short_name": "Release date",
+        "preposition": "from",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "statistics_announcement_state",
+        "name": "State",
+        "short_name": "State",
+        "preposition": "from",
+        "type": "autocomplete",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "display_type",
+        "name": "content_store_document_type",
+        "short_name": "Document type",
+        "preposition": "from",
+        "type": "autocomplete",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "document_collections",
+        "name": "document_collections",
+        "short_name": "Part of a collection",
+        "preposition": "from",
+        "type": "autocomplete",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "topics",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": [
+          "level_one_taxon",
+          "level_two_taxon"
+        ],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "Organisation",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key": "content_store_document_type",
+        "name": "Statistics",
+        "type": "radio",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "hide_facet_tag": true,
+        "preposition": "that are",
+        "option_lookup": {
+          "statistics_published": [
+            "statistics",
+            "national_statistics",
+            "statistical_data_set",
+            "official_statistics"
+          ],
+          "statistics_upcoming": [
+            "statistics_announcement",
+            "national_statistics_announcement",
+            "official_statistics_announcement"
+          ],
+          "research": [
+            "dfid_research_output",
+            "independent_report",
+            "research"
+          ]
+        },
+        "allowed_values": [
+          {
+            "label": "Statistics (published)",
+            "value": "statistics_published",
+            "default": true
+          },
+          {
+            "label": "Statistics (upcoming)",
+            "value": "statistics_upcoming"
+          },
+          {
+            "label": "Research",
+            "value": "research"
+          }
+        ]
+      },
+      {
+        "key": "public_timestamp",
+        "short_name": "Updated",
+        "name": "Updated",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ],
+    "default_documents_per_page": 20
+  },
+  "links": {
+  }
+}

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -178,6 +178,7 @@
             "checkbox",
             "date",
             "hidden",
+            "radio",
             "taxon",
             "text",
             "topical",
@@ -189,6 +190,19 @@
           items: {
             "$ref": "#/definitions/label_value_pair",
           },
+        },
+        option_lookup: {
+          description: "A map of keys to values that can be used to associate allowed_values with multiple values",
+          type: "object",
+          additionalProperties: true,
+          patternProperties: {
+            "^[a-z_]+$": {
+              type: "array",
+              items: {
+                type: "string"
+              }
+            }
+          }
         },
         open_value: {
           description: "Value that determines the open state (the key field is in the future) of a topical facet.",
@@ -211,6 +225,10 @@
           description: "Controls whether Option Select Facet displays a filter field",
           type: "boolean",
         },
+        hide_facet_tag: {
+          description: "Causes the facet to not have a facet tag shown in a finder",
+          type: "boolean"
+        }
       },
     },
   },

--- a/formats/shared/definitions/label_value_pair.jsonnet
+++ b/formats/shared/definitions/label_value_pair.jsonnet
@@ -16,6 +16,10 @@
         description: "A value to use for form controls",
         type: "string",
       },
+      default: {
+        description: "The default option for a radio facet",
+        type: "boolean"
+      }
     },
   },
 }


### PR DESCRIPTION
Update schemas to include recent finder frontend changes. Specifically:

- add `option_lookup` for mapping keys to values that can be used to associate `allowed_values` with multiple values
- add `default` option for `label_value_pair`, so that radio facets can have a default option
- add `hide_facet_tag` key radio facets, where we don't want it to have a facet tag when an option is chosen. This is because radios have to have a default value, so removing it (via the facet tag) is confusing, because it can't be removed, only set to the default state.

Partly related to: https://github.com/alphagov/finder-frontend/pull/922

Trello card: https://trello.com/c/pNXeZLrW/403-introduce-subset-of-supergroup-facet-behaviour-on-stats-finder-m
