### PR TITLE
Add option lookup to finder email signup

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -324,6 +324,19 @@
               },
               "filter_value": {
                 "type": "string"
+              },
+              "option_lookup": {
+                "description": "An array of key values where the key is the value of a selected facet and the value(s) are what these are converted to in a Rummager query",
+                "type": "object",
+                "additionalProperties": true,
+                "patternProperties": {
+                  "^[a-z_]+$": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -424,6 +424,19 @@
               },
               "filter_value": {
                 "type": "string"
+              },
+              "option_lookup": {
+                "description": "An array of key values where the key is the value of a selected facet and the value(s) are what these are converted to in a Rummager query",
+                "type": "object",
+                "additionalProperties": true,
+                "patternProperties": {
+                  "^[a-z_]+$": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -202,6 +202,19 @@
               },
               "filter_value": {
                 "type": "string"
+              },
+              "option_lookup": {
+                "description": "An array of key values where the key is the value of a selected facet and the value(s) are what these are converted to in a Rummager query",
+                "type": "object",
+                "additionalProperties": true,
+                "patternProperties": {
+                  "^[a-z_]+$": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }

--- a/examples/finder_email_signup/publisher_v2/finder_email_signup_multi_facet.json
+++ b/examples/finder_email_signup/publisher_v2/finder_email_signup_multi_facet.json
@@ -53,6 +53,23 @@
             "prechecked": false
           }
         ]
+      },
+      {
+        "facet_id": "facet_three",
+        "facet_name": "Facet three",
+        "option_lookup": {
+          "option_one": [
+            "option_one_value_one",
+            "option_one_value_two"
+          ],
+          "option_two": [
+            "option_two_value_one"
+          ],
+          "option_three": [
+            "option_three_value_one",
+            "option_three_value_two"
+          ]
+        }
       }
     ],
     "subscription_list_title_prefix": {

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -123,6 +123,19 @@
               filter_value: {
                 type: "string",
               },
+              option_lookup: {
+                description: "An array of key values where the key is the value of a selected facet and the value(s) are what these are converted to in a Rummager query",
+                type: "object",
+                additionalProperties: true,
+                patternProperties: {
+                  "^[a-z_]+$": {
+                    type: "array",
+                    items: {
+                      type: "string"
+                    }
+                  }
+                }
+              },
             },
           },
         },


### PR DESCRIPTION
Similar to the finder facet option_lookup field,
this enables one to carry the same behaviour
(associating a single displayed value with multiple
values behind the scenes) from a finder to the email
signup page.


This will enable publication of the policy and consultations email signup page.

Related to https://github.com/alphagov/finder-frontend/pull/936.

https://trello.com/c/tIXZB4LG/482-make-post-review-changes-to-policy-papers-and-consultations-finder