### PR TITLE
Add facet groups links

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/calendar/publisher_v2/links.json
+++ b/dist/formats/calendar/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -190,8 +194,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -70,8 +70,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -90,8 +90,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -198,8 +202,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -187,8 +191,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -89,8 +89,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -109,8 +109,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -206,8 +210,12 @@
         "corporate_information_pages": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -13,8 +13,12 @@
         "corporate_information_pages": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -68,8 +68,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -88,8 +88,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -191,8 +195,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -70,8 +70,12 @@
         "documents": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -90,8 +90,12 @@
         "documents": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -195,8 +199,12 @@
         "documents": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -13,8 +13,12 @@
         "documents": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/facet_value/publisher_v2/links.json
+++ b/dist/formats/facet_value/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "field_of_operation": {

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "field_of_operation": {
@@ -197,8 +201,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "field_of_operation": {

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "field_of_operation": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -70,8 +70,12 @@
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -90,8 +90,12 @@
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -193,8 +197,12 @@
         "email_alert_signup": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -16,8 +16,12 @@
         "email_alert_signup": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -183,8 +187,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -232,8 +232,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -252,8 +252,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -346,8 +350,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -232,8 +232,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -252,8 +252,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -346,8 +350,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -178,8 +182,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -72,8 +72,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -92,8 +92,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -202,8 +206,12 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -15,8 +15,12 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -66,8 +66,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -86,8 +86,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -185,8 +189,12 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -13,8 +13,12 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -66,8 +66,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -86,8 +86,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -185,8 +189,12 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -13,8 +13,12 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -70,8 +70,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -90,8 +90,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -211,8 +215,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -213,8 +217,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/organisation/publisher_v2/links.json
+++ b/dist/formats/organisation/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -189,8 +193,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/person/publisher_v2/links.json
+++ b/dist/formats/person/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -232,8 +232,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "featured_policies": {

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -252,8 +252,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "featured_policies": {
@@ -350,8 +354,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "featured_policies": {

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -86,8 +86,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -106,8 +106,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -220,8 +224,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -78,8 +78,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -98,8 +98,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -204,8 +208,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/role/publisher_v2/links.json
+++ b/dist/formats/role/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -189,8 +193,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/role_appointment/publisher_v2/links.json
+++ b/dist/formats/role_appointment/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -71,8 +71,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -91,8 +91,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -193,8 +197,12 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -14,8 +14,12 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -71,8 +71,12 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -91,8 +91,12 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -189,8 +193,12 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -14,8 +14,12 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -75,8 +75,12 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -95,8 +95,12 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -201,8 +205,12 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -18,8 +18,12 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/dist/formats/service_sign_in/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -235,8 +235,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -255,8 +255,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -349,8 +353,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -86,8 +86,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "finder": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -106,8 +106,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "finder": {
@@ -204,8 +208,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -70,8 +70,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -90,8 +90,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -210,8 +214,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -71,8 +71,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -91,8 +91,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -184,8 +188,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -71,8 +71,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -91,8 +91,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -201,8 +205,12 @@
           "description": "A list of associated taxons whose children should be included as children of this taxon",
           "$ref": "#/definitions/guid_list"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -185,8 +189,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -184,8 +188,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -184,8 +188,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -181,8 +185,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "featured_policies": {

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "featured_policies": {
@@ -185,8 +189,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "featured_policies": {

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -67,8 +67,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -87,8 +87,12 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "lead_organisations": {
@@ -190,8 +194,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
         "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item",
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/formats/shared/base_links.jsonnet
+++ b/formats/shared/base_links.jsonnet
@@ -18,5 +18,6 @@
   original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   lead_organisations: "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
   suggested_ordered_related_items: "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
-  facet_values: "Prototype-stage metadata tagging values for this content item"
+  facet_groups: "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+  facet_values: "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
 }


### PR DESCRIPTION
https://trello.com/c/qI4D3Y7w/246-make-facet-tree-available-to-publishing-api

Finders which present content of different document types need to be able to perform a default query, the `facet_groups` links array allows content to be retrieved without a facet value query.