### PR TITLE
Add Sweden to the export health certificate (EHC) finder

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1511,6 +1511,7 @@
               "sudan",
               "suriname",
               "swaziland-now-eswatini",
+              "sweden",
               "switzerland",
               "syria",
               "taiwan",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1614,6 +1614,7 @@
               "sudan",
               "suriname",
               "swaziland-now-eswatini",
+              "sweden",
               "switzerland",
               "syria",
               "taiwan",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1424,6 +1424,7 @@
               "sudan",
               "suriname",
               "swaziland-now-eswatini",
+              "sweden",
               "switzerland",
               "syria",
               "taiwan",

--- a/examples/specialist_document/frontend/export-health-certificates.json
+++ b/examples/specialist_document/frontend/export-health-certificates.json
@@ -1143,6 +1143,10 @@
                   "value": "swaziland-now-eswatini"
                 },
                 {
+                  "label": "Sweden",
+                  "value": "sweden"
+                },
+                {
                   "label": "Switzerland",
                   "value": "switzerland"
                 },

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1162,6 +1162,7 @@
             "sudan",
             "suriname",
             "swaziland-now-eswatini",
+            "sweden",
             "switzerland",
             "syria",
             "taiwan",


### PR DESCRIPTION
Adds 'Sweden' as a destination country because it was missing from the export health certificate (EHC) finder.

[Trello card](https://trello.com/c/dZIPRphR/826-add-sweden-and-remove-northern-ireland-exception-copy-from-the-exports-form-finder)