### PR TITLE
Link facet group to finder

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -70,6 +70,11 @@
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_group": {
+          "description": "The facet_group this finder uses to define available filters.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
         "facet_groups": {
           "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -90,6 +90,11 @@
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "facet_group": {
+          "description": "The facet_group this finder uses to define available filters.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
         "facet_groups": {
           "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -196,6 +201,11 @@
         },
         "email_alert_signup": {
           "$ref": "#/definitions/guid_list"
+        },
+        "facet_group": {
+          "description": "The facet_group this finder uses to define available filters.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "facet_groups": {
           "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -16,6 +16,11 @@
         "email_alert_signup": {
           "$ref": "#/definitions/guid_list"
         },
+        "facet_group": {
+          "description": "The facet_group this finder uses to define available filters.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "facet_groups": {
           "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
           "$ref": "#/definitions/guid_list"

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -74,5 +74,9 @@
     related: "",
     email_alert_signup: "",
     available_translations: "",
+    facet_group: {
+      description: "The facet_group this finder uses to define available filters.",
+      maxItems: 1,
+    },
   },
 }


### PR DESCRIPTION
https://trello.com/c/ZTNhqTpb/282-finders-get-facet-definition-from-publishing-api

Allows an expanded `facet_group` to be linked to a finder. This should replace static facet definitions in `details["facets"]`.