### PR TITLE
Add content id facet type

### DIFF
--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -299,6 +299,7 @@
           "enum": [
             "autocomplete",
             "checkbox",
+            "content_id",
             "date",
             "hidden",
             "taxon",

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -358,6 +358,7 @@
           "enum": [
             "autocomplete",
             "checkbox",
+            "content_id",
             "date",
             "hidden",
             "taxon",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -235,6 +235,7 @@
           "enum": [
             "autocomplete",
             "checkbox",
+            "content_id",
             "date",
             "hidden",
             "taxon",

--- a/formats/facet.jsonnet
+++ b/formats/facet.jsonnet
@@ -58,6 +58,7 @@
           enum: [
             "autocomplete",
             "checkbox",
+            "content_id",
             "date",
             "hidden",
             "taxon",


### PR DESCRIPTION
https://trello.com/c/ZTNhqTpb/282-finders-get-facet-definition-from-publishing-api

The finder content item definition can be linked to the facet group this expands to include the facets so make sure facets are of the expected `content_id` type which means they will filter based on links to `facet_value` content items.

See https://github.com/alphagov/finder-frontend/pull/944/commits/f8e8f4320e37c408a7ffe4533a5491d34f8b6dce for proposed finder implementation