### PR TITLE
Add ‘Great Britain’ to the export health certificate (EHC) finder

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1396,6 +1396,7 @@
               "germany",
               "ghana",
               "gibraltar",
+              "great-britain",
               "greece",
               "grenada",
               "guam",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1499,6 +1499,7 @@
               "germany",
               "ghana",
               "gibraltar",
+              "great-britain",
               "greece",
               "grenada",
               "guam",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1309,6 +1309,7 @@
               "germany",
               "ghana",
               "gibraltar",
+              "great-britain",
               "greece",
               "grenada",
               "guam",

--- a/examples/specialist_document/frontend/export-health-certificates.json
+++ b/examples/specialist_document/frontend/export-health-certificates.json
@@ -687,6 +687,10 @@
                   "value": "greece"
                 },
                 {
+                  "label": "Great Britain",
+                  "value": "great-britain"
+                },
+                {
                   "label": "Grenada",
                   "value": "grenada"
                 },

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1047,6 +1047,7 @@
             "germany",
             "ghana",
             "gibraltar",
+            "great-britain",
             "greece",
             "grenada",
             "guam",


### PR DESCRIPTION
Add 'Great Britain' as a destination country because it was missing from the export health certificate (EHC) finder.

[Trello card](https://trello.com/c/dZIPRphR/826-add-sweden-and-remove-northern-ireland-exception-copy-from-the-exports-form-finder)