### PR TITLE
Add all content finder schema

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -335,6 +335,9 @@
         "generic_description": {
           "type": "boolean"
         },
+        "hide_facets_by_default": {
+          "$ref": "#/definitions/finder_hide_facets_by_default"
+        },
         "logo_path": {
           "type": "string"
         },
@@ -541,6 +544,10 @@
           }
         }
       }
+    },
+    "finder_hide_facets_by_default": {
+      "description": "Specify this to hide most of the facets behind a toggle on desktop",
+      "type": "boolean"
     },
     "finder_reject_filter": {
       "description": "A fixed filter that rejects documents which match the conditions",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -447,6 +447,9 @@
         "generic_description": {
           "type": "boolean"
         },
+        "hide_facets_by_default": {
+          "$ref": "#/definitions/finder_hide_facets_by_default"
+        },
         "logo_path": {
           "type": "string"
         },
@@ -653,6 +656,10 @@
           }
         }
       }
+    },
+    "finder_hide_facets_by_default": {
+      "description": "Specify this to hide most of the facets behind a toggle on desktop",
+      "type": "boolean"
     },
     "finder_reject_filter": {
       "description": "A fixed filter that rejects documents which match the conditions",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -205,6 +205,9 @@
         "generic_description": {
           "type": "boolean"
         },
+        "hide_facets_by_default": {
+          "$ref": "#/definitions/finder_hide_facets_by_default"
+        },
         "logo_path": {
           "type": "string"
         },
@@ -411,6 +414,10 @@
           }
         }
       }
+    },
+    "finder_hide_facets_by_default": {
+      "description": "Specify this to hide most of the facets behind a toggle on desktop",
+      "type": "boolean"
     },
     "finder_reject_filter": {
       "description": "A fixed filter that rejects documents which match the conditions",

--- a/examples/finder/frontend/all_content.json
+++ b/examples/finder/frontend/all_content.json
@@ -1,0 +1,90 @@
+{
+  "content_id": "dd395436-9b40-41f3-8157-740a453ac972",
+  "base_path": "/search/all",
+  "title": "All content",
+  "description": "Find content from government",
+  "locale": "en",
+  "updated_at": "2019-01-17T13:00:00.000+00:00",
+  "public_updated_at": "2019-01-17T13:00:00.000+00:00",
+  "schema_name": "finder",
+  "document_type": "finder",
+  "details": {
+    "default_documents_per_page": 20,
+    "document_noun": "result",
+    "hide_facets_by_default": true,
+    "facets": [
+      {
+        "key": "topics",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": [
+          "level_one_taxon",
+          "level_two_taxon"
+        ],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "organisations",
+        "name": "Organisation",
+        "preposition": "from",
+        "short_name": "From",
+        "type": "text",
+        "show_option_select_filter": true
+      },
+      {
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "key": "people",
+        "name": "Person",
+        "preposition": "from",
+        "type": "text",
+        "show_option_select_filter": true
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text",
+        "show_option_select_filter": true
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "public_timestamp",
+        "name": "Updated",
+        "short_name": "Updated",
+        "type": "date"
+      }
+    ],
+    "show_summaries": true,
+    "sort": [
+      {
+        "key": "-popularity",
+        "name": "Most viewed"
+      },
+      {
+        "key": "-relevance",
+        "name": "Relevance"
+      },
+      {
+        "default": true,
+        "key": "-public_timestamp",
+        "name": "Updated (newest)"
+      },
+      {
+        "key": "public_timestamp",
+        "name": "Updated (oldest)"
+      }
+    ]
+  },
+  "links": {
+  }
+}

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -31,6 +31,9 @@
         document_noun: {
           "$ref": "#/definitions/finder_document_noun",
         },
+        hide_facets_by_default: {
+          "$ref": "#/definitions/finder_hide_facets_by_default",
+        },
         default_documents_per_page: {
           "$ref": "#/definitions/finder_default_documents_per_page",
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -3,6 +3,10 @@
     description: "How to refer to documents when presenting the search results",
     type: "string",
   },
+  finder_hide_facets_by_default: {
+    description: "Specify this to hide most of the facets behind a toggle on desktop",
+    type: "boolean",
+  },
   finder_default_documents_per_page: {
     description: "Specify this to paginate results",
     type: "integer",


### PR DESCRIPTION
Specifically adds the `hide_facets_by_default` attribute, which is required for https://github.com/alphagov/finder-frontend/pull/960

Trello card: https://trello.com/c/Fy8KPoWV/501-all-content-show-hide-facets