### PR TITLE
Email signup filter values

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -388,6 +388,12 @@
           "prechecked"
         ],
         "properties": {
+          "filter_values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "key": {
             "type": "string"
           },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -488,6 +488,12 @@
           "prechecked"
         ],
         "properties": {
+          "filter_values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "key": {
             "type": "string"
           },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -266,6 +266,12 @@
           "prechecked"
         ],
         "properties": {
+          "filter_values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "key": {
             "type": "string"
           },

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -51,6 +51,12 @@
           "prechecked",
         ],
         properties: {
+          filter_values: {
+            type: "array",
+            items: {
+              type: "string"
+            }
+          },
           key: {
             type: "string",
           },


### PR DESCRIPTION
This will enable us to send an array of values to the email-alert-api, while only displaying one value on the email signup page checkboxes.

An example use case:

```
      {
        "facet_id": "content_store_document_type",
        "facet_name": "Document types",
        "facet_choices": [
          {
            "key": "statistics_published",
            "filter_values": ["statistics", "national_statistics", "statistical_data_set", "official_statistics"],
            "radio_button_name": "Statistics (published)",
            "topic_name": "Statistics (published)",
            "prechecked": false
          },
          {
            "key": "research",
            "filter_values": ["dfid_research_output", "independent_report", "research"],
            "radio_button_name": "Research",
            "topic_name": "Research",
            "prechecked": false
          }
        ]
      },
```

https://trello.com/c/qBt4q04L/548-prevent-users-from-subscribing-to-email-alerts-of-upcoming-statistics