### PR TITLE
Allow facet groups as filter in finder

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -528,6 +528,12 @@
             "type": "string"
           }
         },
+        "facet_groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -640,6 +640,12 @@
             "type": "string"
           }
         },
+        "facet_groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -398,6 +398,12 @@
             "type": "string"
           }
         },
+        "facet_groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -55,6 +55,12 @@
       appear_in_find_eu_exit_guidance_business_finder: {
         type: "string",
       },
+      facet_groups:{
+          type: "array",
+          items: {
+              type: "string",
+          },
+      },
       content_purpose_supergroup: {
         type: "array",
         items: {


### PR DESCRIPTION
We are replacing `appear_in_find_eu_exit_guidance_business_finder` with `facet_groups` to 
query for things appearing in the EU exit business readiness finder,

The schema is preventing us from doing that.

Trello: https://trello.com/c/Sd7omEFH/263-mapping-rummager-request-response-in-finder-frontend