### PR TITLE
Allow email subs with taxonomy filters

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -358,7 +358,13 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "all_part_of_taxonomy_tree": {
+              "type": "string"
+            },
             "content_purpose_supergroup": {
+              "type": "string"
+            },
+            "part_of_taxonomy_tree": {
               "type": "string"
             }
           }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -458,7 +458,13 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "all_part_of_taxonomy_tree": {
+              "type": "string"
+            },
             "content_purpose_supergroup": {
+              "type": "string"
+            },
+            "part_of_taxonomy_tree": {
               "type": "string"
             }
           }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -236,7 +236,13 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "all_part_of_taxonomy_tree": {
+              "type": "string"
+            },
             "content_purpose_supergroup": {
+              "type": "string"
+            },
+            "part_of_taxonomy_tree": {
               "type": "string"
             }
           }

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -155,6 +155,12 @@
             content_purpose_supergroup: {
               type: "string",
             },
+            all_part_of_taxonomy_tree: {
+              type: "string"
+            },
+            part_of_taxonomy_tree: {
+              type: "string"
+            },
           },
         },
         reject: {


### PR DESCRIPTION
We want to allow filtering email subs by topic.

This corresponds with a Citizen Readiness finder: alphagov/rummager@87fc52b

Initially we're setting this up to just allow signups to a particular topic, but in future we want to allow combinations of eg brexit AND education