### PR TITLE
Add ability to no-index a finder

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -341,6 +341,9 @@
         "logo_path": {
           "type": "string"
         },
+        "no_index": {
+          "type": "boolean"
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -453,6 +453,9 @@
         "logo_path": {
           "type": "string"
         },
+        "no_index": {
+          "type": "boolean"
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -211,6 +211,9 @@
         "logo_path": {
           "type": "string"
         },
+        "no_index": {
+          "type": "boolean"
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -25,6 +25,9 @@
             },
           ],
         },
+        no_index: {
+          type: "boolean",
+        },
         generic_description: {
           type: "boolean",
         },


### PR DESCRIPTION
We have some finders that we don't want to appear in external searches because they support other content rather than being useful in isolation.

Rather than hard coding the configuration in finder-frontend, it would be useful to be able to configure it finder by finder.

(This isn't used by any frontend code at the moment)