### PR TITLE
Add research_and_statistics type to finder schema

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -489,6 +489,7 @@
               "hidden",
               "hidden_clearable",
               "radio",
+              "research_and_statistics",
               "taxon",
               "text",
               "topical"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -601,6 +601,7 @@
               "hidden",
               "hidden_clearable",
               "radio",
+              "research_and_statistics",
               "taxon",
               "text",
               "topical"

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -359,6 +359,7 @@
               "hidden",
               "hidden_clearable",
               "radio",
+              "research_and_statistics",
               "taxon",
               "text",
               "topical"

--- a/examples/finder/frontend/statistics.json
+++ b/examples/finder/frontend/statistics.json
@@ -116,6 +116,15 @@
         "filterable": true
       },
       {
+        "key": "format",
+        "name": "Research And Statistics",
+        "type": "research_and_statistics",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "hide_facet_tag": true,
+        "preposition": "that are"
+      },
+      {
         "key": "content_store_document_type",
         "name": "Statistics",
         "type": "radio",

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -190,9 +190,10 @@
             "hidden",
             "hidden_clearable",
             "radio",
+            "research_and_statistics",
             "taxon",
             "text",
-            "topical",
+            "topical"
           ],
         },
         allowed_values: {


### PR DESCRIPTION
A new research_and_statistics facet was introduced to Finder Frontend.

trello: https://trello.com/c/mkf4eUXF/593-bug-stats-finder-displaying-wrong-number-of-published-stats-docs
trello: https://trello.com/c/QpM8Vhwv/590-bug-stats-finder-is-only-displaying-a-few-upcoming-stats-docs
github: https://github.com/alphagov/finder-frontend/pull/1053