### PR TITLE
Add content_purpose_subgroup to filter options in finder schema

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -512,6 +512,12 @@
         "appear_in_find_eu_exit_guidance_business_finder": {
           "type": "string"
         },
+        "content_purpose_subgroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -624,6 +624,12 @@
         "appear_in_find_eu_exit_guidance_business_finder": {
           "type": "string"
         },
+        "content_purpose_subgroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -382,6 +382,12 @@
         "appear_in_find_eu_exit_guidance_business_finder": {
           "type": "string"
         },
+        "content_purpose_subgroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -361,6 +361,12 @@
             "all_part_of_taxonomy_tree": {
               "type": "string"
             },
+            "content_purpose_subgroup": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "content_purpose_supergroup": {
               "type": "string"
             },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -461,6 +461,12 @@
             "all_part_of_taxonomy_tree": {
               "type": "string"
             },
+            "content_purpose_subgroup": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "content_purpose_supergroup": {
               "type": "string"
             },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -239,6 +239,12 @@
             "all_part_of_taxonomy_tree": {
               "type": "string"
             },
+            "content_purpose_subgroup": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "content_purpose_supergroup": {
               "type": "string"
             },

--- a/examples/finder/frontend/news-and-communications.json
+++ b/examples/finder/frontend/news-and-communications.json
@@ -1,0 +1,154 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/search/news-and-communications",
+  "content_id": "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2",
+  "document_type": "finder",
+  "first_published_at": "2019-02-01T12:31:51.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-04-09T15:00:18.000+00:00",
+  "publishing_app": "rummager",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder",
+  "title": "News and communications",
+  "updated_at": "2019-04-09T17:47:23.943Z",
+  "withdrawn_notice": {
+  },
+  "publishing_request_id": "21022-1554822019.550-10.3.3.1-388",
+  "links": {
+    "email_alert_signup": [
+      {
+        "api_path": "/api/content/search/news-and-communications/email-signup",
+        "base_path": "/search/news-and-communications/email-signup",
+        "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+        "description": "You'll get an email each time news or communications are published.",
+        "document_type": "finder_email_signup",
+        "locale": "en",
+        "public_updated_at": "2019-04-09T15:00:18Z",
+        "schema_name": "finder_email_signup",
+        "title": "News and communications",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/search/news-and-communications/email-signup",
+        "web_url": "https://www.gov.uk/search/news-and-communications/email-signup"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "News and communications",
+        "public_updated_at": "2019-04-09T15:00:18Z",
+        "document_type": "finder",
+        "schema_name": "finder",
+        "base_path": "/search/news-and-communications",
+        "description": "Find news and communications from government",
+        "api_path": "/api/content/search/news-and-communications",
+        "withdrawn": false,
+        "content_id": "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/search/news-and-communications",
+        "web_url": "https://www.gov.uk/search/news-and-communications",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "Find news and communications from government",
+  "details": {
+    "document_noun": "result",
+    "filter": {
+      "content_purpose_subgroup": [
+        "news",
+        "speeches_and_statements"
+      ]
+    },
+    "format_name": "News or communications",
+    "show_summaries": true,
+    "sort": [
+      {
+        "name": "Most viewed",
+        "key": "-popularity"
+      },
+      {
+        "name": "Relevance",
+        "key": "-relevance"
+      },
+      {
+        "name": "Updated (newest)",
+        "key": "-public_timestamp",
+        "default": true
+      },
+      {
+        "name": "Updated (oldest)",
+        "key": "public_timestamp"
+      }
+    ],
+    "facets": [
+      {
+        "key": "related_to_brexit",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        "name": "Show only Brexit results",
+        "short_name": "Brexit",
+        "type": "checkbox",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "key": "_unused",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": [
+          "level_one_taxon",
+          "level_two_taxon"
+        ],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "From",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "show_option_select_filter": true
+      },
+      {
+        "key": "people",
+        "name": "Person",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "show_option_select_filter": true
+      },
+      {
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "show_option_select_filter": true
+      },
+      {
+        "key": "public_timestamp",
+        "short_name": "Updated",
+        "name": "Updated",
+        "preposition": "Updated",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ],
+    "default_documents_per_page": 20
+  }
+}

--- a/examples/finder_email_signup/frontend/news-and-communications-email-signup.json
+++ b/examples/finder_email_signup/frontend/news-and-communications-email-signup.json
@@ -1,0 +1,82 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/search/news-and-communications/email-signup",
+  "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+  "document_type": "finder_email_signup",
+  "first_published_at": "2019-02-05T11:50:59.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-04-09T15:00:18.000+00:00",
+  "publishing_app": "rummager",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
+  "title": "News and communications",
+  "updated_at": "2019-04-09T15:00:19.425Z",
+  "withdrawn_notice": {
+  },
+  "publishing_request_id": "1894-1554822018.782-10.3.3.1-388",
+  "links": {
+    "available_translations": [
+      {
+        "title": "News and communications",
+        "public_updated_at": "2019-04-09T15:00:18Z",
+        "document_type": "finder_email_signup",
+        "schema_name": "finder_email_signup",
+        "base_path": "/search/news-and-communications/email-signup",
+        "description": "You'll get an email each time news or communications are published.",
+        "api_path": "/api/content/search/news-and-communications/email-signup",
+        "withdrawn": false,
+        "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/search/news-and-communications/email-signup",
+        "web_url": "https://www.gov.uk/search/news-and-communications/email-signup",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "You'll get an email each time news or communications are published.",
+  "details": {
+    "filter": {
+      "content_purpose_subgroup": [
+        "news",
+        "speeches_and_statements"
+      ]
+    },
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "News and communications ",
+    "email_filter_facets": [
+      {
+        "facet_id": "people",
+        "facet_name": "people"
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "related_to_brexit",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -152,6 +152,12 @@
           type: "object",
           additionalProperties: false,
           properties: {
+            content_purpose_subgroup: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
             content_purpose_supergroup: {
               type: "string",
             },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -55,11 +55,17 @@
       appear_in_find_eu_exit_guidance_business_finder: {
         type: "string",
       },
-      facet_groups:{
+      facet_groups: {
           type: "array",
           items: {
               type: "string",
           },
+      },
+      content_purpose_subgroup: {
+        type: "array",
+        items: {
+          type: "string",
+        },
       },
       content_purpose_supergroup: {
         type: "array",


### PR DESCRIPTION
Trello: https://trello.com/c/hG5slHr3/667-exclude-specialist-doc-types-from-news-n-comms-finder
github: https://github.com/alphagov/search-api/pull/1521