### PR TITLE
Add alternative format email for orgs

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -334,6 +334,13 @@
             "null"
           ]
         },
+        "alternative_format_contact_email": {
+          "description": "The organisation's email for requesting an alternative format for attachments",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -468,6 +468,13 @@
             "null"
           ]
         },
+        "alternative_format_contact_email": {
+          "description": "The organisation's email for requesting an alternative format for attachments",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -213,6 +213,13 @@
             "null"
           ]
         },
+        "alternative_format_contact_email": {
+          "description": "The organisation's email for requesting an alternative format for attachments",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -15,6 +15,13 @@
         analytics_identifier: {
           "$ref": "#/definitions/analytics_identifier",
         },
+        alternative_format_contact_email: {
+          type: [
+            "string",
+            "null",
+          ],
+          description: "The organisation's email for requesting an alternative format for attachments",
+        },
         body: {
           "$ref": "#/definitions/body",
         },


### PR DESCRIPTION
https://trello.com/c/OcuVomSb/820-determine-the-alternative-format-email-address-for-an-attachment

This adds a new field to store an email that specifies how a user can
request an alternative format from the organisation e.g. for an
attachment.