### PR TITLE
Add secondary to step by steps

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/calendar/publisher_v2/links.json
+++ b/dist/formats/calendar/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -140,6 +140,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -160,6 +160,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -253,6 +257,10 @@
           "maxItems": 1
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -67,6 +67,10 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -152,6 +152,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -172,6 +172,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -270,6 +274,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -79,6 +79,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -140,6 +140,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -160,6 +160,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -250,6 +254,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -67,6 +67,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -159,6 +159,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -179,6 +179,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -267,6 +271,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -67,6 +67,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -147,6 +147,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -167,6 +167,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -260,6 +264,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -73,6 +73,10 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -146,6 +146,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -166,6 +166,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -261,6 +265,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -76,6 +76,10 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/external_content/notification/schema.json
+++ b/dist/formats/external_content/notification/schema.json
@@ -103,6 +103,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -96,6 +96,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -116,6 +116,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet_group/frontend/schema.json
+++ b/dist/formats/facet_group/frontend/schema.json
@@ -91,6 +91,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet_group/notification/schema.json
+++ b/dist/formats/facet_group/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/facet_value/publisher_v2/links.json
+++ b/dist/formats/facet_value/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -153,6 +153,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -173,6 +173,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -274,6 +278,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -80,6 +80,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -148,6 +148,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -168,6 +168,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -266,6 +270,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -78,6 +78,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -139,6 +139,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -159,6 +159,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -245,6 +249,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -66,6 +66,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -303,6 +303,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -323,6 +323,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -408,6 +412,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -303,6 +303,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -323,6 +323,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -408,6 +412,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -83,6 +83,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -108,6 +108,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -134,6 +134,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -154,6 +154,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -236,6 +240,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -83,6 +83,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -103,6 +103,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -149,6 +149,10 @@
           "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -169,6 +169,10 @@
           "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -269,6 +273,10 @@
         },
         "second_level_browse_pages": {
           "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -76,6 +76,10 @@
           "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -135,6 +135,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "sections": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -155,6 +155,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "sections": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
@@ -245,6 +249,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "sections": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -66,6 +66,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "sections": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -138,6 +138,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -158,6 +158,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -248,6 +252,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -69,6 +69,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -155,6 +155,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -175,6 +175,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -286,6 +290,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -79,6 +79,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -169,6 +169,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -189,6 +189,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -306,6 +310,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/organisation/publisher_v2/links.json
+++ b/dist/formats/organisation/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -145,6 +145,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -165,6 +165,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -258,6 +262,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/person/publisher_v2/links.json
+++ b/dist/formats/person/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -307,6 +307,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -327,6 +327,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -416,6 +420,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -171,6 +171,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -191,6 +191,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -295,6 +299,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -82,6 +82,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -86,6 +86,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -160,6 +160,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -180,6 +180,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -277,6 +281,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/role/publisher_v2/links.json
+++ b/dist/formats/role/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -145,6 +145,10 @@
           "description": "The role that the relevant person is currently appointed to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -165,6 +165,10 @@
           "description": "The role that the relevant person is currently appointed to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -257,6 +261,10 @@
         },
         "role": {
           "description": "The role that the relevant person is currently appointed to.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/role_appointment/publisher_v2/links.json
+++ b/dist/formats/role_appointment/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -141,6 +141,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "service_manual_topics": {
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -161,6 +161,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "service_manual_topics": {
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -254,6 +258,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "service_manual_topics": {
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -68,6 +68,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "service_manual_topics": {
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -141,6 +141,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -161,6 +161,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -250,6 +254,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -68,6 +68,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -149,6 +149,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -169,6 +169,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -266,6 +270,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -76,6 +76,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/dist/formats/service_sign_in/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -306,6 +306,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -326,6 +326,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -411,6 +415,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -177,6 +177,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -262,6 +266,10 @@
         },
         "primary_publishing_organisation": {
           "description": "The primary organisation for this document",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -155,6 +155,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "speaker": {
           "description": "A speaker that has a GOV.UK profile",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -175,6 +175,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "speaker": {
           "description": "A speaker that has a GOV.UK profile",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -285,6 +289,10 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "speaker": {

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -79,6 +79,10 @@
           "description": "Government roles that are associated with this document, typically the role part of a role association",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "speaker": {
           "description": "A speaker that has a GOV.UK profile",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -140,6 +140,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -160,6 +160,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -244,6 +248,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -62,6 +62,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -79,6 +79,10 @@
           "description": "A list of content that is related to this step by step navigation journey",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "pages_secondary_to_step_nav": {
+          "description": "A list of content items that may be a part of but not essential to completing this step by step navigation journey.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -92,6 +96,10 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "related_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "secondary_to_step_by_steps": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -99,6 +99,10 @@
           "description": "A list of content that is related to this step by step navigation journey",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "pages_secondary_to_step_nav": {
+          "description": "A list of content items that may be a part of but not essential to completing this step by step navigation journey.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -112,6 +116,10 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "related_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "secondary_to_step_by_steps": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
@@ -141,6 +149,10 @@
         },
         "pages_related_to_step_nav": {
           "description": "A list of content that is related to this step by step navigation journey",
+          "$ref": "#/definitions/guid_list"
+        },
+        "pages_secondary_to_step_nav": {
+          "description": "A list of content items that may be a part of but not essential to completing this step by step navigation journey.",
           "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -63,6 +63,10 @@
           "description": "A list of content that is related to this step by step navigation journey",
           "$ref": "#/definitions/guid_list"
         },
+        "pages_secondary_to_step_nav": {
+          "description": "A list of content items that may be a part of but not essential to completing this step by step navigation journey.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -153,6 +153,10 @@
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -173,6 +173,10 @@
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -273,6 +277,10 @@
         },
         "root_taxon": {
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -76,6 +76,10 @@
           "description": "Set to the root taxon (homepage) if this is a level one taxon.",
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -141,6 +141,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -161,6 +161,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -250,6 +254,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -68,6 +68,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -140,6 +140,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -160,6 +160,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -247,6 +251,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -67,6 +67,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -140,6 +140,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -160,6 +160,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -247,6 +251,10 @@
           "maxItems": 1
         },
         "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
           "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -67,6 +67,10 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topic_taxonomy_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -242,6 +246,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -141,6 +141,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -161,6 +161,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -250,6 +254,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -137,6 +137,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -157,6 +157,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -251,6 +255,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -64,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "secondary_to_step_by_steps": {
+          "description": "Step by steps that a content items may be a part of but is not essential to completing it.",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"

--- a/examples/publication/frontend/best-practice-guidance.json
+++ b/examples/publication/frontend/best-practice-guidance.json
@@ -190,6 +190,236 @@
         "links": {
         }
       }
+    ],
+    "secondary_to_step_by_steps": [
+      {
+        "title": "Learn to drive a car: step by step",
+        "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+        "publishing_app": "collections-publisher",
+        "rendering_app": "collections",
+        "locale": "en",
+        "updated_at": "2018-01-18T15:46:10.000+00:00",
+        "public_updated_at": "2018-01-18T15:46:10.000+00:00",
+        "document_type": "step_by_step_nav",
+        "schema_name": "step_by_step_nav",
+        "base_path": "/learn-to-drive-a-car",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "links": {
+          "pages_secondary_to_step_nav": [
+            {
+              "api_path": "/api/content/government/publications/car-and-small-van-driving-syllabus",
+              "base_path": "/government/publications/car-and-small-van-driving-syllabus",
+              "content_id": "5e5dc201-7631-11e4-a3cb-005056011aef",
+              "document_type": "guidance",
+              "locale": "en",
+              "public_updated_at": "2014-11-24T15:00:02.000+00:00",
+              "schema_name": "publication",
+              "title": "Learning to drive a car syllabus",
+              "withdrawn": false
+            }
+          ]
+        },
+        "details": {
+          "step_by_step_nav": {
+            "title": "Learn to drive a car: step by step",
+            "introduction": "<p>Check what you need to do to learn to drive.</p>",
+            "steps": [
+              {
+                "title": "Check you're allowed to drive",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "Most people can start learning to drive when they’re 17."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/vehicles-can-drive",
+                        "text": "Check what age you can drive"
+                      },
+                      {
+                        "href": "/legal-obligations-drivers-riders",
+                        "text": "Requirements for driving legally"
+                      },
+                      {
+                        "href": "/driving-eyesight-rules",
+                        "text": "Driving eyesight rules"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Get a provisional driving licence",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/apply-first-provisional-driving-licence",
+                        "text": "Apply for your first provisional driving licence",
+                        "context": "£34"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Driving lessons and practice",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to take lessons or practice."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/guidance/the-highway-code",
+                        "text": "The Highway Code"
+                      },
+                      {
+                        "href": "/driving-lessons-learning-to-drive",
+                        "text": "Taking driving lessons"
+                      },
+                      {
+                        "href": "/find-driving-schools-and-lessons",
+                        "text": "Find driving schools, lessons and instructors"
+                      },
+                      {
+                        "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                        "text": "Practise vehicle safety questions"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Prepare for your theory test",
+                "logic": "and",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/theory-test/revision-and-practice",
+                        "text": "Theory test revision and practice"
+                      },
+                      {
+                        "href": "/take-practice-theory-test",
+                        "text": "Take a practice theory test"
+                      },
+                      {
+                        "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                        "text": "Theory and hazard perception test app"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your theory test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to book your theory test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-theory-test",
+                        "text": "Book your theory test",
+                        "context": "£23"
+                      },
+                      {
+                        "href": "/theory-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-theory-test",
+                        "text": "Change your theory test appointment"
+                      },
+                      {
+                        "href": "/check-theory-test",
+                        "text": "Check your theory test appointment details"
+                      },
+                      {
+                        "href": "/cancel-theory-test",
+                        "text": "Cancel your theory test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your driving test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You must pass your theory test before you can book your driving test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-driving-test",
+                        "text": "Book your driving test",
+                        "context": "£62"
+                      },
+                      {
+                        "href": "/driving-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "text": "Change your driving test appointment"
+                      },
+                      {
+                        "href": "/check-driving-test",
+                        "text": "Check your driving test appointment details"
+                      },
+                      {
+                        "href": "/cancel-driving-test",
+                        "text": "Cancel your driving test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "When you pass",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You can start driving as soon as you pass your driving test."
+                  },
+                  {
+                    "type": "paragraph",
+                    "text": "You must have an insurance policy that allows you to drive without supervision."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/pass-plus",
+                        "text": "Find out about Pass Plus training courses"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
     ]
   },
   "description": "The syllabus sets out a way of teaching people the skills, knowledge and understanding they need to be a safe and responsible car or light van driver.",

--- a/examples/step_by_step_nav/frontend/learn_to_drive_a_car.json
+++ b/examples/step_by_step_nav/frontend/learn_to_drive_a_car.json
@@ -11,6 +11,19 @@
   "base_path": "/learn-to-drive-a-car",
   "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
   "links": {
+    "pages_secondary_to_step_nav": [
+      {
+        "api_path": "/api/content/government/publications/car-and-small-van-driving-syllabus",
+        "base_path": "/government/publications/car-and-small-van-driving-syllabus",
+        "content_id": "5e5dc201-7631-11e4-a3cb-005056011aef",
+        "document_type": "guidance",
+        "locale": "en",
+        "public_updated_at": "2014-11-24T15:00:02.000+00:00",
+        "schema_name": "publication",
+        "title": "Learning to drive a car syllabus",
+        "withdrawn": false
+      }
+    ]
   },
   "details": {
     "step_by_step_nav": {

--- a/formats/shared/base_links.jsonnet
+++ b/formats/shared/base_links.jsonnet
@@ -20,5 +20,6 @@
   suggested_ordered_related_items: "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
   facet_groups: "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
   facet_values: "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-  finder: "Powers links from content back to finders the content is surfaced on"
+  finder: "Powers links from content back to finders the content is surfaced on",
+  secondary_to_step_by_steps: "Step by steps that a content items may be a part of but is not essential to completing it."
 }

--- a/formats/shared/definitions/_secondary_to_step_by_steps.jsonnet
+++ b/formats/shared/definitions/_secondary_to_step_by_steps.jsonnet
@@ -1,0 +1,12 @@
+{
+  secondary_to_step_by_steps: {
+    type: "array",
+    items: {
+      "$ref": "#/definitions/secondary_to_step_by_step",
+    },
+  },
+  secondary_to_step_by_step: {
+    type: "object",
+    additionalProperties: false
+  },
+}

--- a/formats/step_by_step_nav.jsonnet
+++ b/formats/step_by_step_nav.jsonnet
@@ -3,7 +3,8 @@
   publishing_app: "required",
   edition_links: (import "shared/base_edition_links.jsonnet") + {
     pages_part_of_step_nav: "A list of content that should be navigable via this step by step journey",
-    pages_related_to_step_nav: "A list of content that is related to this step by step navigation journey"
+    pages_related_to_step_nav: "A list of content that is related to this step by step navigation journey",
+    pages_secondary_to_step_nav: "A list of content items that may be a part of but not essential to completing this step by step navigation journey."
   },
   links: {
   },

--- a/lib/schema_generator/expanded_links.rb
+++ b/lib/schema_generator/expanded_links.rb
@@ -39,6 +39,10 @@ module SchemaGenerator
       # a reverse link to determine where the replacement Topic Taxonomy taxon
       # now resides
       "topic_taxonomy_taxons",
+
+      # Step by steps that a content items may be a part of but is not essential
+      # to completing it.
+      "pages_secondary_to_step_nav",
     ].freeze
 
     def initialize(format)


### PR DESCRIPTION
Adds secondary to step by steps so that a
content item can link to a step by step as it 
may be a part of the process but it is not
essential to completing it.

Trello: https://trello.com/c/5zRe5f7F/96-step-by-step-update-the-content-schemas-to-allow-secondary-content-to-be-linked-to-a-step-by-step