### PR TITLE
Rename content-performance-manager

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ def dependentApplications = [
   ['collections-publisher', true],
   ['collections', true],
   ['contacts', true],
-  ['content-performance-manager', true],
+  ['content-data-api', true],
   ['content-store', true],
   ['content-tagger', true],
   ['email-alert-frontend', true],


### PR DESCRIPTION
content-performance-manager has been renamed to content-data-api

Fixes: https://ci.integration.publishing.service.gov.uk/job/govuk-content-schemas/job/add-secondary-step-by-step-items/6/console
`ERROR: No item named /content-performance-manager/deployed-to-production found`