### PR TITLE
Add new fields to service standard reports

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2380,8 +2380,12 @@
           "type": "string",
           "enum": [
             "alpha",
+            "alpha-reassessment",
             "beta",
-            "live"
+            "beta-reassessment",
+            "live",
+            "live-reassessment",
+            "live-review"
           ]
         }
       }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2536,8 +2536,12 @@
           "type": "string",
           "enum": [
             "alpha",
+            "alpha-reassessment",
             "beta",
-            "live"
+            "beta-reassessment",
+            "live",
+            "live-reassessment",
+            "live-review"
           ]
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2188,8 +2188,12 @@
           "type": "string",
           "enum": [
             "alpha",
+            "alpha-reassessment",
             "beta",
-            "live"
+            "beta-reassessment",
+            "live",
+            "live-reassessment",
+            "live-review"
           ]
         }
       }

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1974,8 +1974,12 @@
         type: "string",
         enum: [
           "alpha",
+          "alpha-reassessment",
           "beta",
+          "beta-reassessment",
           "live",
+          "live-reassessment",
+          "live-review",
         ],
       },
       service_provider: {


### PR DESCRIPTION
This [Specialist Publisher PR](https://github.com/alphagov/specialist-publisher/pull/1431) adds some additional fields to the Service Standard Reports stage facet


[trello](https://trello.com/c/FjYzSTIh/1008-add-new-facet-options-to-service-standard-reports-finder)