### PR TITLE
Link reject finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -597,6 +597,12 @@
             "type": "string"
           }
         },
+        "link": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "policies": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -713,6 +713,12 @@
             "type": "string"
           }
         },
+        "link": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "policies": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -459,6 +459,12 @@
             "type": "string"
           }
         },
+        "link": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "policies": {
           "type": "array",
           "items": {

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -134,6 +134,12 @@
           type: "string",
         },
       },
+      link: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
     },
   },
   finder_facets: {


### PR DESCRIPTION
Adds an additional possible rejection filter to the finder schema, so we can block results with particular links. This is being done as part of [this ticket](https://trello.com/c/qAwjASRS/176-remove-the-search-page-from-search-results-searchception-s)