### PR TITLE
Add official_documents type to finder schema

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -496,6 +496,7 @@
               "date",
               "hidden",
               "hidden_clearable",
+              "official_documents",
               "radio",
               "research_and_statistics",
               "taxon",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -612,6 +612,7 @@
               "date",
               "hidden",
               "hidden_clearable",
+              "official_documents",
               "radio",
               "research_and_statistics",
               "taxon",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -358,6 +358,7 @@
               "date",
               "hidden",
               "hidden_clearable",
+              "official_documents",
               "radio",
               "research_and_statistics",
               "taxon",

--- a/examples/finder/frontend/official-documents.json
+++ b/examples/finder/frontend/official-documents.json
@@ -1,0 +1,103 @@
+{
+  "base_path":"/search/official-documents",
+  "content_id":"e96a1b16-a011-4dc6-9f6a-a54561c4db90",
+  "document_type":"finder",
+  "first_published_at":"2019-05-29 11:41:00 +0100",
+  "locale":"en",
+  "public_updated_at":"2019-05-29 11:41:00 +0100",
+  "publishing_app":"finder-frontend",
+  "rendering_app":"finder-frontend",
+  "schema_name":"finder",
+  "title":"Official Documents",
+  "updated_at":"2019-05-29 11:41:00 +0100",
+  "withdrawn_notice":{},
+  "publishing_request_id":"",
+  "links":{},
+  "description":"Find official documents from government",
+  "details":{
+    "document_noun":"result",
+    "filter":{
+      "has_official_document":true
+    },
+    "format_name":"Official documents",
+    "show_summaries":true,
+    "sort": [
+      {
+        "name": "Most viewed",
+        "key": "-popularity"
+      },
+      {
+        "name": "Relevance",
+        "key": "-relevance"
+      },
+      {
+        "name": "Updated (newest)",
+        "key": "-public_timestamp",
+        "default": true
+      },
+      {
+        "name": "Updated (oldest)",
+        "key": "public_timestamp"
+      }
+    ],
+    "facets":[
+      {
+        "key": "release_timestamp",
+        "name": "release_timestamp",
+        "short_name": "Release date",
+        "preposition": "from",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "display_type",
+        "name": "content_store_document_type",
+        "short_name": "Document type",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "topics",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": ["level_one_taxon","level_two_taxon"],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "key":"content_store_document_type",
+        "name":"official documents",
+        "type":"official_documents",
+        "preposition": "of type",
+        "display_as_result_metadata":true,
+        "filterable":true
+      },
+      {
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "Organisation",
+        "preposition": "from",
+        "type": "text",
+        "show_option_select_filter": true,
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key": "public_timestamp",
+        "short_name": "Updated",
+        "name": "Updated",
+        "preposition": "Updated",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ],
+    "default_documents_per_page":20
+  }
+}

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -91,6 +91,9 @@
       format: {
         type: "string",
       },
+      has_official_document: {
+        type: "boolean"
+      },
       organisations: {
         type: "array",
         items: {
@@ -201,6 +204,7 @@
             "date",
             "hidden",
             "hidden_clearable",
+            "official_documents",
             "radio",
             "research_and_statistics",
             "taxon",


### PR DESCRIPTION
Adds the official documents finder to the content schemas. 

https://trello.com/c/6xFJqfAw/724-spin-up-finder-for-content-that-has-official-doc-status-s