### PR TITLE
Add combine_mode to email alert signup

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -299,6 +299,14 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "combine_mode": {
+          "description": "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
+          "type": "string",
+          "enum": [
+            "",
+            "or"
+          ]
+        },
         "email_filter_by": {
           "oneOf": [
             {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -403,6 +403,14 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "combine_mode": {
+          "description": "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
+          "type": "string",
+          "enum": [
+            "",
+            "or"
+          ]
+        },
         "email_filter_by": {
           "oneOf": [
             {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -169,6 +169,14 @@
         "beta": {
           "$ref": "#/definitions/finder_beta"
         },
+        "combine_mode": {
+          "description": "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
+          "type": "string",
+          "enum": [
+            "",
+            "or"
+          ]
+        },
         "email_filter_by": {
           "oneOf": [
             {

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -178,6 +178,14 @@
             },
           },
         },
+        combine_mode: {
+          type: "string",
+          description: "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
+          enum: [
+            "",
+            "or",
+          ],
+        },
       },
     },
   },


### PR DESCRIPTION
This parameter will be added to email-alert-api
and a finder-frontend will need to pass it to
the api selectively.

Existing finders will want to continue using
'and' (which can be represented either with
a blank string or omitting the parameter)
while the business finder will want to use
'or' joining

Trello: https://trello.com/c/vLZ7zTdR/132-add-parameter-to-finder-frontend-to-make-email-alert-api-know-this-finder-is-special