### PR TITLE
Add local-links-manager to publishing apps

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -559,6 +559,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -697,6 +697,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -324,6 +324,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -529,6 +529,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -648,6 +648,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -275,6 +275,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -625,6 +625,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -753,6 +753,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -386,6 +386,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -532,6 +532,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -651,6 +651,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -278,6 +278,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -569,6 +569,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -688,6 +688,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -315,6 +315,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -751,6 +751,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -884,6 +884,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -543,6 +543,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -760,6 +760,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -895,6 +895,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -507,6 +507,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -643,6 +643,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -765,6 +765,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -427,6 +427,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -700,6 +700,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -828,6 +828,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -461,6 +461,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -627,6 +627,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -757,6 +757,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -413,6 +413,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -593,6 +593,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -712,6 +712,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -339,6 +339,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/external_content/notification/schema.json
+++ b/dist/formats/external_content/notification/schema.json
@@ -447,6 +447,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -268,6 +268,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -542,6 +542,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -618,6 +618,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -348,6 +348,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet_group/frontend/schema.json
+++ b/dist/formats/facet_group/frontend/schema.json
@@ -476,6 +476,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet_group/notification/schema.json
+++ b/dist/formats/facet_group/notification/schema.json
@@ -547,6 +547,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -287,6 +287,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -538,6 +538,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -667,6 +667,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -291,6 +291,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -568,6 +568,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -704,6 +704,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -352,6 +352,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -916,6 +916,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1049,6 +1049,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -652,6 +652,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -687,6 +687,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -808,6 +808,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -431,6 +431,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -688,6 +688,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -807,6 +807,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -434,6 +434,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -714,6 +714,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -833,6 +833,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -460,6 +460,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -400,6 +400,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -428,6 +428,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -269,6 +269,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -588,6 +588,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -726,6 +726,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -353,6 +353,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -559,6 +559,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -697,6 +697,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -324,6 +324,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -644,6 +644,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -763,6 +763,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -390,6 +390,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -648,6 +648,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -767,6 +767,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -394,6 +394,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -394,6 +394,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -451,6 +451,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -268,6 +268,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -554,6 +554,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -670,6 +670,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -318,6 +318,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -390,6 +390,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -436,6 +436,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -264,6 +264,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -578,6 +578,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -716,6 +716,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -343,6 +343,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -602,6 +602,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -740,6 +740,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -367,6 +367,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -561,6 +561,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -689,6 +689,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -284,6 +284,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -638,6 +638,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -781,6 +781,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -402,6 +402,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -621,6 +621,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -764,6 +764,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -385,6 +385,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -589,6 +589,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -708,6 +708,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -335,6 +335,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -661,6 +661,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -807,6 +807,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -433,6 +433,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -1039,6 +1039,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -1190,6 +1190,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -785,6 +785,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -605,6 +605,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -724,6 +724,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -351,6 +351,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -599,6 +599,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -745,6 +745,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -364,6 +364,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -568,6 +568,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -706,6 +706,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -333,6 +333,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -824,6 +824,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -947,6 +947,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -570,6 +570,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -680,6 +680,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -819,6 +819,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -472,6 +472,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -373,6 +373,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -388,6 +388,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -255,6 +255,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -581,6 +581,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -741,6 +741,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -354,6 +354,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -541,6 +541,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -678,6 +678,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -294,6 +294,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -580,6 +580,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -707,6 +707,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -342,6 +342,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -522,6 +522,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -641,6 +641,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -268,6 +268,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -538,6 +538,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -661,6 +661,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -280,6 +280,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -571,6 +571,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -690,6 +690,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -317,6 +317,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -551,6 +551,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -675,6 +675,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -278,6 +278,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -613,6 +613,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -751,6 +751,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -378,6 +378,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -621,6 +621,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -759,6 +759,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -386,6 +386,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -661,6 +661,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -780,6 +780,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -428,6 +428,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2174,6 +2174,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2313,6 +2313,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1976,6 +1976,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -678,6 +678,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -823,6 +823,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -422,6 +422,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -588,6 +588,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -707,6 +707,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -367,6 +367,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -561,6 +561,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -679,6 +679,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -308,6 +308,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -456,6 +456,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -544,6 +544,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -349,6 +349,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -578,6 +578,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -697,6 +697,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -324,6 +324,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -549,6 +549,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -684,6 +684,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -287,6 +287,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -539,6 +539,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -655,6 +655,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -274,6 +274,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -536,6 +536,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -655,6 +655,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -282,6 +282,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -632,6 +632,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -770,6 +770,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -397,6 +397,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -668,6 +668,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -809,6 +809,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -430,6 +430,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -546,6 +546,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -668,6 +668,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -289,6 +289,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -545,6 +545,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -664,6 +664,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -291,6 +291,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -378,6 +378,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -532,6 +532,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -651,6 +651,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -278,6 +278,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -568,6 +568,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -701,6 +701,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -322,6 +322,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -632,6 +632,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -760,6 +760,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -393,6 +393,7 @@
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",
+        "local-links-manager",
         "manuals-frontend",
         "manuals-publisher",
         "maslow",

--- a/formats/shared/definitions/publishing_app.jsonnet
+++ b/formats/shared/definitions/publishing_app.jsonnet
@@ -16,6 +16,7 @@
       "hmrc-manuals-api",
       "info-frontend",
       "licencefinder",
+      "local-links-manager",
       "manuals-frontend",
       "manuals-publisher",
       "maslow",


### PR DESCRIPTION
It will publish redirects for local authorities that no longer exist.

This is needed by https://github.com/alphagov/local-links-manager/pull/454.

[Trello Card](https://trello.com/c/rxlRSgAR/988-bulk-url-redirects-from-old-authorities-to-new-incarnations)