### PR TITLE
Add accessibility statement as corporate information page type

### DIFF
--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -53,7 +53,8 @@
         "equality_and_diversity",
         "staff_update",
         "terms_of_reference",
-        "petitions_and_campaigns"
+        "petitions_and_campaigns",
+        "accessibility_statement"
       ]
     },
     "first_published_at": {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -79,7 +79,8 @@
         "equality_and_diversity",
         "staff_update",
         "terms_of_reference",
-        "petitions_and_campaigns"
+        "petitions_and_campaigns",
+        "accessibility_statement"
       ]
     },
     "email_document_supertype": {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -59,7 +59,8 @@
         "equality_and_diversity",
         "staff_update",
         "terms_of_reference",
-        "petitions_and_campaigns"
+        "petitions_and_campaigns",
+        "accessibility_statement"
       ]
     },
     "first_published_at": {

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -37,6 +37,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -63,6 +63,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -43,6 +43,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -37,6 +37,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -63,6 +63,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -43,6 +43,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -37,6 +37,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -63,6 +63,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -43,6 +43,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -40,6 +40,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -66,6 +66,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -43,6 +43,7 @@
         "aaib_report",
         "about",
         "about_our_services",
+        "accessibility_statement",
         "access_and_opening",
         "ambassador_role",
         "answer",

--- a/formats/corporate_information_page.jsonnet
+++ b/formats/corporate_information_page.jsonnet
@@ -20,6 +20,7 @@
     "staff_update",
     "terms_of_reference",
     "petitions_and_campaigns",
+    "accessibility_statement",
   ],
   definitions: {
     details: {

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -1,6 +1,7 @@
 - aaib_report
 - about
 - about_our_services
+- accessibility_statement
 - access_and_opening
 - ambassador_role
 - answer


### PR DESCRIPTION
<img width="793" alt="Screen Shot 2019-06-11 at 12 49 03" src="https://user-images.githubusercontent.com/109225/59271100-08d31d80-8c4b-11e9-990f-0e30bc58f1b9.png">
<img width="1134" alt="Screen Shot 2019-06-11 at 12 50 27" src="https://user-images.githubusercontent.com/109225/59271101-08d31d80-8c4b-11e9-8579-b696b7481e45.png">
<img width="1165" alt="Screen Shot 2019-06-11 at 13 05 28" src="https://user-images.githubusercontent.com/109225/59271102-096bb400-8c4b-11e9-83db-ede2afbe5396.png">
<img width="1021" alt="Screen Shot 2019-06-11 at 13 06 18" src="https://user-images.githubusercontent.com/109225/59271103-096bb400-8c4b-11e9-8705-232b5c73a7bc.png">
<img width="943" alt="Screen Shot 2019-06-11 at 13 13 15" src="https://user-images.githubusercontent.com/109225/59271104-096bb400-8c4b-11e9-9a08-b3f786d3828e.png">

https://trello.com/c/Wb01UcFK/1046-add-accessibility-statement-to-list-of-corporate-information-for-organisations-whitehall-publisher