### PR TITLE
Update guide example to add suggested_ordered_related_items

### DIFF
--- a/examples/guide/frontend/guide.json
+++ b/examples/guide/frontend/guide.json
@@ -508,6 +508,99 @@
         "web_url": "http://www.dev.gov.uk/types-of-school"
       }
     ],
+    "suggested_ordered_related_items": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/home-schooling-information-council",
+        "base_path": "/home-schooling-information-council",
+        "content_id": "3ab90258-f0c5-4ea7-b3c9-09cab7619f37",
+        "description": "Your responsibilities with your local council if you want to educate your child at home - sometimes called home schooling",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2012-05-18T14:08:42Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Home education: get information from your council",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting/schools-education",
+              "base_path": "/browse/childcare-parenting/schools-education",
+              "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+              "description": "Sending a child to school, financial support, dealing with the school",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-11T14:45:03Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and education",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/education/school-admissions-transport",
+              "base_path": "/browse/education/school-admissions-transport",
+              "content_id": "61778a6b-d0e8-4b75-85a9-8ec2e333581a",
+              "description": "Applying for a school place, home schooling and travel costs",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:41Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "School admissions and transport to school",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/education",
+                    "base_path": "/browse/education",
+                    "content_id": "4ba04d39-1f8c-4117-89f5-73ec4f1b48e8",
+                    "description": "Get help if you’re at school, planning to go on to further or higher education, looking for training or interested in a student or career development loan.",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Education and learning",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/education",
+                    "web_url": "http://www.dev.gov.uk/browse/education"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-admissions-transport",
+              "web_url": "http://www.dev.gov.uk/browse/education/school-admissions-transport"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/home-schooling-information-council",
+        "web_url": "http://www.dev.gov.uk/home-schooling-information-council"
+      }
+    ],
     "organisations": [
       {
         "analytics_identifier": "D6",


### PR DESCRIPTION
This PR updates the `guide` example to add `suggested_ordered_related_items`. This is used as part of tests within `government-frontend` to ensure `ordered_related_items` is not overwritten with `suggested_ordered_related_items` if existing `ordered_related_items` exist.