### PR TITLE
Add opt in and opt out URL for organ donor promotion

### DIFF
--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -296,11 +296,45 @@
         },
         "promotion": {
           "type": "object",
-          "required": [
-            "category",
-            "url"
-          ],
           "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "mot_reminder"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "organ_donor"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "register_to_vote"
+                  ]
+                }
+              }
+            }
+          ],
           "properties": {
             "category": {
               "enum": [
@@ -308,6 +342,14 @@
                 "organ_donor",
                 "register_to_vote"
               ]
+            },
+            "opt_in_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "opt_out_url": {
+              "type": "string",
+              "format": "uri"
             },
             "url": {
               "type": "string",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -398,11 +398,45 @@
         },
         "promotion": {
           "type": "object",
-          "required": [
-            "category",
-            "url"
-          ],
           "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "mot_reminder"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "organ_donor"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "register_to_vote"
+                  ]
+                }
+              }
+            }
+          ],
           "properties": {
             "category": {
               "enum": [
@@ -410,6 +444,14 @@
                 "organ_donor",
                 "register_to_vote"
               ]
+            },
+            "opt_in_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "opt_out_url": {
+              "type": "string",
+              "format": "uri"
             },
             "url": {
               "type": "string",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -168,11 +168,45 @@
         },
         "promotion": {
           "type": "object",
-          "required": [
-            "category",
-            "url"
-          ],
           "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "mot_reminder"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "organ_donor"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "register_to_vote"
+                  ]
+                }
+              }
+            }
+          ],
           "properties": {
             "category": {
               "enum": [
@@ -180,6 +214,14 @@
                 "organ_donor",
                 "register_to_vote"
               ]
+            },
+            "opt_in_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "opt_out_url": {
+              "type": "string",
+              "format": "uri"
             },
             "url": {
               "type": "string",

--- a/examples/completed_transaction/frontend/completed_transaction_with_organ_donor_promotion.json
+++ b/examples/completed_transaction/frontend/completed_transaction_with_organ_donor_promotion.json
@@ -1,0 +1,50 @@
+{
+  "details": {
+    "external_related_links": [
+
+    ],
+    "promotion": {
+      "url": "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/registration_form.asp",
+      "opt_in_url": "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/registration_form.asp",
+      "opt_out_url": "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/registration_form.asp",
+      "category": "organ_donor"
+    }
+  },
+  "description": "",
+  "links": {
+    "available_translations": [
+      {
+        "links": {
+        },
+        "web_url": "http://www.dev.gov.uk/done/view-driving-licence",
+        "api_url": "http://www.dev.gov.uk/api/content/done/view-driving-licence",
+        "locale": "en",
+        "content_id": "9e9c357e-58cd-4b35-bd57-2c072760a166",
+        "withdrawn": false,
+        "title": "Thank you",
+        "public_updated_at": "2016-06-28T13:40:57Z",
+        "analytics_identifier": null,
+        "document_type": "completed_transaction",
+        "schema_name": "completed_transaction",
+        "base_path": "/done/view-driving-licence",
+        "description": "",
+        "api_path": "/api/content/done/view-driving-licence"
+      }
+    ]
+  },
+  "locale": "en",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "document_type": "completed_transaction",
+  "content_id": "9e9c357e-58cd-4b35-bd57-2c072760a166",
+  "base_path": "/done/view-driving-licence",
+  "analytics_identifier": null,
+  "phase": "live",
+  "public_updated_at": "2016-06-28T13:40:57.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "frontend",
+  "schema_name": "completed_transaction",
+  "title": "Thank you",
+  "updated_at": "2017-02-24T16:03:17.091Z",
+  "withdrawn_notice": {
+  }
+}

--- a/formats/completed_transaction.jsonnet
+++ b/formats/completed_transaction.jsonnet
@@ -23,6 +23,14 @@
               type: "string",
               format: "uri",
             },
+            opt_in_url: {
+              type: "string",
+              format: "uri",
+            },
+            opt_out_url: {
+              type: "string",
+              format: "uri",
+            },
           },
           oneOf: [
             {

--- a/formats/completed_transaction.jsonnet
+++ b/formats/completed_transaction.jsonnet
@@ -11,10 +11,6 @@
         promotion: {
           type: "object",
           additionalProperties: false,
-          required: [
-            "category",
-            "url",
-          ],
           properties: {
             category: {
               enum: [
@@ -28,6 +24,26 @@
               format: "uri",
             },
           },
+          oneOf: [
+            {
+              properties: {
+                category: { enum: ["mot_reminder"] }
+              },
+              required: ["url"]
+            },
+            {
+              properties: {
+                category: { enum: ["organ_donor"] }
+              },
+              required: ["url"]
+            },
+            {
+              properties: {
+                category: { enum: ["register_to_vote"] }
+              },
+              required: ["url"]
+            },
+          ]
         },
       },
     },


### PR DESCRIPTION
The content of this promotion page will be changing to include two URLs, an opt in and an opt out URL.

This adds new optional `opt_in_url` and `opt_out_url` fields to the promotion.

Once all the content items for this schema have been moved over to use these URLs, we can mandate that they are required and remove `url` from the required list.

I've implemented this by adding support for custom list of `requires` depending on the promotion category. See https://stackoverflow.com/a/38781027 for more information.

[Trello Card](https://trello.com/c/HFsNGxTy/1088-investigate-organ-donation-promos-on-done-pages)