### PR TITLE
Revert "Add state aid type and outcomes to CMA cases"

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -643,8 +643,7 @@
             "mergers",
             "consumer-enforcement",
             "regulatory-references-and-appeals",
-            "review-of-orders-and-undertakings",
-            "state-aid"
+            "review-of-orders-and-undertakings"
           ]
         },
         "closed_date": {
@@ -723,15 +722,7 @@
             "consumer-enforcement-court-order",
             "consumer-enforcement-undertakings",
             "consumer-enforcement-changes-to-business-practices-agreed",
-            "regulatory-references-and-appeals-final-determination",
-            "state-aid-no-aid",
-            "state-aid-aid-approved",
-            "state-aid-conditional-decision",
-            "state-aid-aid-not-approved",
-            "state-aid-investigation",
-            "state-aid-recommendation-accepted",
-            "state-aid-recommendation-implemented",
-            "state-aid-aid-not-misused"
+            "regulatory-references-and-appeals-final-determination"
           ]
         }
       }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -746,8 +746,7 @@
             "mergers",
             "consumer-enforcement",
             "regulatory-references-and-appeals",
-            "review-of-orders-and-undertakings",
-            "state-aid"
+            "review-of-orders-and-undertakings"
           ]
         },
         "closed_date": {
@@ -826,15 +825,7 @@
             "consumer-enforcement-court-order",
             "consumer-enforcement-undertakings",
             "consumer-enforcement-changes-to-business-practices-agreed",
-            "regulatory-references-and-appeals-final-determination",
-            "state-aid-no-aid",
-            "state-aid-aid-approved",
-            "state-aid-conditional-decision",
-            "state-aid-aid-not-approved",
-            "state-aid-investigation",
-            "state-aid-recommendation-accepted",
-            "state-aid-recommendation-implemented",
-            "state-aid-aid-not-misused"
+            "regulatory-references-and-appeals-final-determination"
           ]
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -552,8 +552,7 @@
             "mergers",
             "consumer-enforcement",
             "regulatory-references-and-appeals",
-            "review-of-orders-and-undertakings",
-            "state-aid"
+            "review-of-orders-and-undertakings"
           ]
         },
         "closed_date": {
@@ -632,15 +631,7 @@
             "consumer-enforcement-court-order",
             "consumer-enforcement-undertakings",
             "consumer-enforcement-changes-to-business-practices-agreed",
-            "regulatory-references-and-appeals-final-determination",
-            "state-aid-no-aid",
-            "state-aid-aid-approved",
-            "state-aid-conditional-decision",
-            "state-aid-aid-not-approved",
-            "state-aid-investigation",
-            "state-aid-recommendation-accepted",
-            "state-aid-recommendation-implemented",
-            "state-aid-aid-not-misused"
+            "regulatory-references-and-appeals-final-determination"
           ]
         }
       }

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -325,7 +325,6 @@
           "consumer-enforcement",
           "regulatory-references-and-appeals",
           "review-of-orders-and-undertakings",
-          "state-aid",
         ],
       },
       case_state: {
@@ -404,14 +403,6 @@
           "consumer-enforcement-undertakings",
           "consumer-enforcement-changes-to-business-practices-agreed",
           "regulatory-references-and-appeals-final-determination",
-          "state-aid-no-aid",
-          "state-aid-aid-approved",
-          "state-aid-conditional-decision",
-          "state-aid-aid-not-approved",
-          "state-aid-investigation",
-          "state-aid-recommendation-accepted",
-          "state-aid-recommendation-implemented",
-          "state-aid-aid-not-misused",
         ],
       },
       opened_date: {


### PR DESCRIPTION
Reverts alphagov/govuk-content-schemas#907

We need to delay deploying this until after brexit.