### PR TITLE
Use organisation ids and user ids for access limiting

### DIFF
--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -169,6 +169,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -137,6 +137,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -172,6 +172,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -131,6 +131,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -157,6 +157,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -122,6 +122,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -137,6 +137,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -137,6 +137,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -137,6 +137,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -160,6 +160,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -131,6 +131,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -297,6 +297,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -297,6 +297,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -128,6 +128,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -131,6 +131,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -145,6 +145,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -126,6 +126,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -162,6 +162,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -162,6 +162,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -138,6 +138,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -300,6 +300,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -191,6 +191,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -128,6 +128,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -161,6 +161,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -145,6 +145,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -297,6 +297,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -212,6 +212,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -133,6 +133,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -139,6 +139,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -134,6 +134,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -142,6 +142,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -138,6 +138,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -142,6 +142,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -130,6 +130,12 @@
           "description": "A list of ids that will allow access to this item for non-authenticated users",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "users": {
           "type": "array",
           "items": {

--- a/formats/shared/definitions/publishing_api_base.jsonnet
+++ b/formats/shared/definitions/publishing_api_base.jsonnet
@@ -15,6 +15,12 @@
           type: "string",
         },
       },
+      organisations: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       auth_bypass_ids: {
         "$ref": "#/definitions/guid_list",
         description: "A list of ids that will allow access to this item for non-authenticated users",


### PR DESCRIPTION
This changes the publishing_api's content schema to accept organisation
ids as well as user ids for access limiting. This is due to the changes
content publisher are making on how access limiting works.

Trello:
https://trello.com/c/wxp1XkSg/969-update-govuk-to-support-access-limiting-by-organisation