### PR TITLE
Wait and propagate dependant app builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,8 @@ stage("Check dependent projects against updated schema") {
           [$class: 'StringParameterValue',
             name: 'SCHEMA_COMMIT',
             value: env.GIT_COMMIT]
-        ], wait: false
+        ],
+        propagate: true
     }
   }
 


### PR DESCRIPTION
And propagate the build result, so that the build results for
dependant applications are taken in to account for the GitHub branch
protection configuration.

Previously, as the main job is the only one taken in to account for
the branch protections, Pull Requests could be merged when the changes
were incompatible with applications.

