### PR TITLE
This uses the given definition for a guid list for orgs

### DIFF
--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -170,10 +170,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -138,10 +138,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -173,10 +173,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -132,10 +132,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -158,10 +158,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -123,10 +123,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -138,10 +138,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -138,10 +138,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -138,10 +138,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -161,10 +161,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -132,10 +132,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -298,10 +298,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -298,10 +298,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -129,10 +129,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -132,10 +132,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -146,10 +146,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -127,10 +127,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -163,10 +163,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -163,10 +163,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -139,10 +139,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -301,10 +301,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -192,10 +192,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -129,10 +129,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -162,10 +162,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -146,10 +146,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -298,10 +298,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -213,10 +213,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -134,10 +134,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -140,10 +140,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -135,10 +135,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -143,10 +143,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -139,10 +139,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -143,10 +143,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -131,10 +131,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
         },
         "users": {
           "type": "array",

--- a/formats/shared/definitions/publishing_api_base.jsonnet
+++ b/formats/shared/definitions/publishing_api_base.jsonnet
@@ -16,10 +16,8 @@
         },
       },
       organisations: {
-        type: "array",
-        items: {
-          type: "string",
-        },
+        "$ref": "#/definitions/guid_list",
+        description: "A list of organisation content ids permitted access to this item",
       },
       auth_bypass_ids: {
         "$ref": "#/definitions/guid_list",


### PR DESCRIPTION
Stops hardcoding the org list to only contain strings and to
use the given definition for a list of guids

based on comments on #912