### PR TITLE
 Add ivory-coast to allowed countries for UK MCABs

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2630,6 +2630,7 @@
               "ireland",
               "israel",
               "italy",
+              "ivory-coast",
               "jamaica",
               "japan",
               "jordan",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2786,6 +2786,7 @@
               "ireland",
               "israel",
               "italy",
+              "ivory-coast",
               "jamaica",
               "japan",
               "jordan",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2442,6 +2442,7 @@
               "ireland",
               "israel",
               "italy",
+              "ivory-coast",
               "jamaica",
               "japan",
               "jordan",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -550,6 +550,7 @@
             "ireland",
             "israel",
             "italy",
+            "ivory-coast",
             "jamaica",
             "japan",
             "jordan",


### PR DESCRIPTION
Attempting to create a document which applies to all countries fails
with errors about Jamaica, Lebanon, and the Ivory Coast.  Jamaica and
Lebanon are failing because they should be lowercase (fixed in
specialist-publisher), Ivory Coast is failing because it's missing
from the schema.

---

[Trello card](https://trello.com/c/3CyH4j89/892-specialist-publisher-schema-validation-errors)