### PR TITLE
Add tribunal organisation type

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -646,7 +646,8 @@
             "other",
             "public_corporation",
             "sub_organisation",
-            "tribunal_ndpb"
+            "tribunal_ndpb",
+            "tribunal"
           ]
         },
         "secondary_corporate_information_pages": {

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -780,7 +780,8 @@
             "other",
             "public_corporation",
             "sub_organisation",
-            "tribunal_ndpb"
+            "tribunal_ndpb",
+            "tribunal"
           ]
         },
         "secondary_corporate_information_pages": {

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -522,7 +522,8 @@
             "other",
             "public_corporation",
             "sub_organisation",
-            "tribunal_ndpb"
+            "tribunal_ndpb",
+            "tribunal"
           ]
         },
         "secondary_corporate_information_pages": {

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -838,6 +838,9 @@
               "sub_organisation": {
                 "$ref": "#/definitions/list_of_sub_organisations"
               },
+              "tribunal": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
               "tribunal_ndpb": {
                 "$ref": "#/definitions/list_of_sub_organisations"
               }

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -974,6 +974,9 @@
               "sub_organisation": {
                 "$ref": "#/definitions/list_of_sub_organisations"
               },
+              "tribunal": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
               "tribunal_ndpb": {
                 "$ref": "#/definitions/list_of_sub_organisations"
               }

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -594,6 +594,9 @@
               "sub_organisation": {
                 "$ref": "#/definitions/list_of_sub_organisations"
               },
+              "tribunal": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
               "tribunal_ndpb": {
                 "$ref": "#/definitions/list_of_sub_organisations"
               }

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -315,6 +315,7 @@
             "public_corporation",
             "sub_organisation",
             "tribunal_ndpb",
+            "tribunal",
           ],
           description: "The type of organisation.",
         },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -279,6 +279,9 @@
             tribunal_ndpb: {
               "$ref": "#/definitions/list_of_sub_organisations",
             },
+            tribunal: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
           },
         },
       },


### PR DESCRIPTION
**What**

Any organisation that has a tribunal type is labelled 'tribunal non-departmental public body'.

However, many organisations are tribunal bodies but are departmental public bodies (such as HMCTS). There is only one type tag available (non-DPB), so we should rename this type as 'Tribunal' to cover both types of organisations.

**Why**

Not all organisations fit into the current type tagging. The current tag is very specific - we should make it easier for publishers by changing the type name to a more generic 'Tribunal'.

https://trello.com/c/KHXlOF6V/1191-change-organisation-type-tribunal-non-departmental-public-body-to-tribunal