### PR TITLE
 Start removing superflous fields for `facet`

### DIFF
--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -233,22 +233,16 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "filterable",
-        "key",
-        "name",
-        "type"
-      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
         "closed_value": {
-          "description": "Value that determines the closed state (the key field is in the past) of a topical facet."
+          "description": "DEPRECATED - This field isn't used."
         },
         "combine_mode": {
-          "description": "Specifies how to combine with other facets",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string",
           "default": "and",
           "enum": [
@@ -257,48 +251,49 @@
           ]
         },
         "display_as_result_metadata": {
-          "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "boolean"
         },
         "filter_key": {
-          "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "filter_value": {
-          "description": "A preset filter value that is applied when a checkbox is selected",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "filterable": {
-          "description": "This must be true to show the facet to users.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "boolean"
         },
         "key": {
-          "description": "The rummager field name used for this facet.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "keys": {
-          "description": "Field names used for the taxon drop down.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "name": {
-          "description": "Label for the facet.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "open_value": {
-          "description": "Value that determines the open state (the key field is in the future) of a topical facet."
+          "description": "DEPRECATED - This field isn't used."
         },
         "preposition": {
-          "description": "Text used to augment the description of the search when the facet is used.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "short_name": {
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "type": {
-          "description": "Defines the UI component and how the facet is queried from the search API",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string",
           "enum": [
             "autocomplete",

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -292,22 +292,16 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "filterable",
-        "key",
-        "name",
-        "type"
-      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
         "closed_value": {
-          "description": "Value that determines the closed state (the key field is in the past) of a topical facet."
+          "description": "DEPRECATED - This field isn't used."
         },
         "combine_mode": {
-          "description": "Specifies how to combine with other facets",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string",
           "default": "and",
           "enum": [
@@ -316,48 +310,49 @@
           ]
         },
         "display_as_result_metadata": {
-          "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "boolean"
         },
         "filter_key": {
-          "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "filter_value": {
-          "description": "A preset filter value that is applied when a checkbox is selected",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "filterable": {
-          "description": "This must be true to show the facet to users.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "boolean"
         },
         "key": {
-          "description": "The rummager field name used for this facet.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "keys": {
-          "description": "Field names used for the taxon drop down.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "name": {
-          "description": "Label for the facet.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "open_value": {
-          "description": "Value that determines the open state (the key field is in the future) of a topical facet."
+          "description": "DEPRECATED - This field isn't used."
         },
         "preposition": {
-          "description": "Text used to augment the description of the search when the facet is used.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "short_name": {
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "type": {
-          "description": "Defines the UI component and how the facet is queried from the search API",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string",
           "enum": [
             "autocomplete",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -168,19 +168,13 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "filterable",
-        "key",
-        "name",
-        "type"
-      ],
       "additionalProperties": false,
       "properties": {
         "closed_value": {
-          "description": "Value that determines the closed state (the key field is in the past) of a topical facet."
+          "description": "DEPRECATED - This field isn't used."
         },
         "combine_mode": {
-          "description": "Specifies how to combine with other facets",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string",
           "default": "and",
           "enum": [
@@ -189,48 +183,49 @@
           ]
         },
         "display_as_result_metadata": {
-          "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "boolean"
         },
         "filter_key": {
-          "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "filter_value": {
-          "description": "A preset filter value that is applied when a checkbox is selected",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "filterable": {
-          "description": "This must be true to show the facet to users.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "boolean"
         },
         "key": {
-          "description": "The rummager field name used for this facet.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "keys": {
-          "description": "Field names used for the taxon drop down.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "name": {
-          "description": "Label for the facet.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "open_value": {
-          "description": "Value that determines the open state (the key field is in the future) of a topical facet."
+          "description": "DEPRECATED - This field isn't used."
         },
         "preposition": {
-          "description": "Text used to augment the description of the search when the facet is used.",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "short_name": {
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string"
         },
         "type": {
-          "description": "Defines the UI component and how the facet is queried from the search API",
+          "description": "DEPRECATED - This field isn't used.",
           "type": "string",
           "enum": [
             "autocomplete",

--- a/examples/facet/publisher_v2/facet.json
+++ b/examples/facet/publisher_v2/facet.json
@@ -5,9 +5,5 @@
   "schema_name": "facet",
   "title": "Sector / Business area",
   "details": {
-    "filterable": true,
-    "key": "sector_business_area",
-    "name": "Sector / Business area",
-    "type": "text"
   }
 }

--- a/formats/facet.jsonnet
+++ b/formats/facet.jsonnet
@@ -7,53 +7,48 @@
     details: {
       type: "object",
       additionalProperties: false,
-      required: [
-        "filterable",
-        "key",
-        "name",
-        "type",
-      ],
       properties: {
         filter_key: {
-          description: "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
         },
         filter_value: {
-          description: "A preset filter value that is applied when a checkbox is selected",
+          description: "DEPRECATED - This field isn't used.",
           type: "string"
         },
         key: {
-          description: "The rummager field name used for this facet.",
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
         },
         keys: {
-          description: "Field names used for the taxon drop down.",
+          description: "DEPRECATED - This field isn't used.",
           type: "array",
           items: {
             type: "string",
           },
         },
         filterable: {
-          description: "This must be true to show the facet to users.",
+          description: "DEPRECATED - This field isn't used.",
           type: "boolean",
         },
         display_as_result_metadata: {
-          description: "Include this in search result metadata. Can be set for non-filterable facets.",
+          description: "DEPRECATED - This field isn't used.",
           type: "boolean",
         },
         name: {
-          description: "Label for the facet.",
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
         },
         preposition: {
-          description: "Text used to augment the description of the search when the facet is used.",
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
         },
         short_name: {
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
         },
         type: {
-          description: "Defines the UI component and how the facet is queried from the search API",
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
           enum: [
             "autocomplete",
@@ -67,13 +62,13 @@
           ],
         },
         open_value: {
-          description: "Value that determines the open state (the key field is in the future) of a topical facet.",
+          description: "DEPRECATED - This field isn't used.",
         },
         closed_value: {
-          description: "Value that determines the closed state (the key field is in the past) of a topical facet.",
+          description: "DEPRECATED - This field isn't used.",
         },
         combine_mode: {
-          description: "Specifies how to combine with other facets",
+          description: "DEPRECATED - This field isn't used.",
           type: "string",
           enum: [
             "and",


### PR DESCRIPTION
In my (really quite limited) understanding, the fields that are defined in the `facet` schema aren't actually used for anything. 

- They're not used in the content-tagger tagger UI that people use to tag content
- They're not used in finder-frontend and search-api because we never expose the `facet` of a content item (only the `facet_group` and `facet_value`)

I'm 100% confident about this! Please tell me if I'm wrong.