### PR TITLE
Switch rummager -> search-api in dependant applications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def dependentApplications = [
   'manuals-publisher',
   'publisher',
   'publishing-api',
-  'rummager',
+  'search-api',
   'search-admin',
   'service-manual-frontend',
   'service-manual-publisher',


### PR DESCRIPTION
As rummager was renamed to the search-api quite a while ago.