### PR TITLE
Remove the "optional" option from Step by Step pages

### DIFF
--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -361,9 +361,6 @@
             "or"
           ]
         },
-        "optional": {
-          "type": "boolean"
-        },
         "title": {
           "type": "string"
         }

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -426,9 +426,6 @@
             "or"
           ]
         },
-        "optional": {
-          "type": "boolean"
-        },
         "title": {
           "type": "string"
         }

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -239,9 +239,6 @@
             "or"
           ]
         },
-        "optional": {
-          "type": "boolean"
-        },
         "title": {
           "type": "string"
         }

--- a/examples/step_by_step_nav/frontend/step_by_step_nav.json
+++ b/examples/step_by_step_nav/frontend/step_by_step_nav.json
@@ -32,7 +32,6 @@
       "steps": [
         {
           "title": "Get support and advice",
-          "optional": true,
           "contents": [
             {
               "type": "paragraph",
@@ -79,7 +78,6 @@
         },
         {
           "title": "Make arrangements for your children, money and property",
-          "optional": true,
           "contents": [
             {
               "type": "paragraph",

--- a/examples/step_by_step_nav/publisher_v2/step_by_step_nav.json
+++ b/examples/step_by_step_nav/publisher_v2/step_by_step_nav.json
@@ -32,7 +32,6 @@
       "steps": [
         {
           "title": "Get support and advice",
-          "optional": true,
           "contents": [
             {
               "type": "paragraph",
@@ -79,7 +78,6 @@
         },
         {
           "title": "Make arrangements for your children, money and property",
-          "optional": true,
           "contents": [
             {
               "type": "paragraph",

--- a/formats/shared/definitions/_step_by_step_nav.jsonnet
+++ b/formats/shared/definitions/_step_by_step_nav.jsonnet
@@ -40,9 +40,6 @@
           "or"
         ]
       },
-      optional: {
-        type: "boolean"
-      },
       contents: {
         type: "array",
         items: {


### PR DESCRIPTION
This is being removed as it was confusing users so should be removed from schemas

Pr to remove "optional" from Collections publisher
https://github.com/alphagov/collections-publisher/pull/787

Trello card
https://trello.com/c/P1mSis5e/97-hide-optional-vs-essential-question-when-editing-step