### PR TITLE
Allow auth_bypass_ids outside access_limited

### DIFF
--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -166,7 +170,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -134,7 +138,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -169,7 +173,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -128,7 +132,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -154,7 +158,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -17,6 +17,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "type": "null"
     },
@@ -119,7 +123,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -134,7 +138,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -134,7 +138,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -134,7 +138,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -157,7 +161,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -128,7 +132,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -294,7 +298,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -294,7 +298,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -14,6 +14,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -125,7 +129,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -128,7 +132,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -142,7 +146,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -123,7 +127,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -159,7 +163,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -159,7 +163,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -135,7 +139,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -297,7 +301,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -188,7 +192,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -125,7 +129,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -17,6 +17,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -158,7 +162,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -142,7 +146,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -16,6 +16,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -294,7 +298,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -209,7 +213,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -130,7 +134,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -136,7 +140,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -131,7 +135,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -139,7 +143,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -135,7 +139,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -17,6 +17,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
@@ -139,7 +143,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -19,6 +19,10 @@
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -127,7 +131,7 @@
       "additionalProperties": false,
       "properties": {
         "auth_bypass_ids": {
-          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/formats/shared/default_properties/publisher.jsonnet
+++ b/formats/shared/default_properties/publisher.jsonnet
@@ -2,6 +2,10 @@
   access_limited: {
     "$ref": "#/definitions/access_limited",
   },
+  auth_bypass_ids: {
+    description: "A list of ids that will allow access to this item for non-authenticated users",
+    "$ref": "#/definitions/guid_list",
+  },
   bulk_publishing: {
     type: "boolean",
   },

--- a/formats/shared/definitions/publishing_api_base.jsonnet
+++ b/formats/shared/definitions/publishing_api_base.jsonnet
@@ -21,7 +21,7 @@
       },
       auth_bypass_ids: {
         "$ref": "#/definitions/guid_list",
-        description: "A list of ids that will allow access to this item for non-authenticated users",
+        description: "Deprecated: auth_bypass_ids should be sent as a separate field",
       },
     },
   },


### PR DESCRIPTION
Trello: https://trello.com/c/DnYanQdY/132-separate-auth-bypassing-from-access-limiting-in-publishing-api

This adds a new field that Publishing API can accept of auth_bypass_ids,
this is part of work to separate auth_bypass_ids from access_limits.
These are being separated because auth_bypass_ids are not a part of
access limiting and can be set independent of that feature.

They auth_bypass_ids field in access_limited has been marked as
deprecated and will continue to be so until there is a drive to update
all GOV.UK publishing apps to not use it.