### PR TITLE
Done pages have a new 'electric vehicle' promo choice

### DIFF
--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -333,6 +333,18 @@
                   ]
                 }
               }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "electric_vehicle"
+                  ]
+                }
+              }
             }
           ],
           "properties": {
@@ -340,7 +352,8 @@
               "enum": [
                 "mot_reminder",
                 "organ_donor",
-                "register_to_vote"
+                "register_to_vote",
+                "electric_vehicle"
               ]
             },
             "opt_in_url": {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -435,6 +435,18 @@
                   ]
                 }
               }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "electric_vehicle"
+                  ]
+                }
+              }
             }
           ],
           "properties": {
@@ -442,7 +454,8 @@
               "enum": [
                 "mot_reminder",
                 "organ_donor",
-                "register_to_vote"
+                "register_to_vote",
+                "electric_vehicle"
               ]
             },
             "opt_in_url": {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -213,6 +213,18 @@
                   ]
                 }
               }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
+                    "electric_vehicle"
+                  ]
+                }
+              }
             }
           ],
           "properties": {
@@ -220,7 +232,8 @@
               "enum": [
                 "mot_reminder",
                 "organ_donor",
-                "register_to_vote"
+                "register_to_vote",
+                "electric_vehicle"
               ]
             },
             "opt_in_url": {

--- a/formats/completed_transaction.jsonnet
+++ b/formats/completed_transaction.jsonnet
@@ -17,6 +17,7 @@
                 "mot_reminder",
                 "organ_donor",
                 "register_to_vote",
+                "electric_vehicle",
               ],
             },
             url: {
@@ -48,6 +49,12 @@
             {
               properties: {
                 category: { enum: ["register_to_vote"] }
+              },
+              required: ["url"]
+            },
+            {
+              properties: {
+                category: { enum: ["electric_vehicle"] }
               },
               required: ["url"]
             },


### PR DESCRIPTION
- The government has a goal to reach zero carbon emissions by 2050, and
  electric cars are part of that.
- Content designers can now select "electric vehicles" as their promo of
  choice.
- These schemas need to be updates to include 'electric_vehicle' as a
  valid option.

https://trello.com/c/FmE5xU1p/1478-3-add-new-bespoke-message-to-specific-completed-transaction-pages