### PR TITLE
Use body definition for person and roles

### DIFF
--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -261,13 +261,9 @@
         }
       ]
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
     },
     "change_history": {
       "type": "array",
@@ -308,7 +304,7 @@
           "$ref": "#/definitions/analytics_identifier"
         },
         "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+          "$ref": "#/definitions/body"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -371,13 +371,9 @@
         }
       ]
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
     },
     "change_history": {
       "type": "array",
@@ -418,7 +414,7 @@
           "$ref": "#/definitions/analytics_identifier"
         },
         "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+          "$ref": "#/definitions/body"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
@@ -700,25 +696,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "content": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          }
-        }
-      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -165,13 +165,9 @@
         }
       ]
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
     },
     "description_optional": {
       "anyOf": [
@@ -191,7 +187,7 @@
           "$ref": "#/definitions/analytics_identifier"
         },
         "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+          "$ref": "#/definitions/body"
         },
         "full_name": {
           "description": "Name of the person, including titles and any letters, eg: 'Sir Lord Snoopy DOG'",
@@ -331,25 +327,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "content": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          }
-        }
-      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -276,13 +276,9 @@
         }
       ]
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
     },
     "change_history": {
       "type": "array",
@@ -331,7 +327,7 @@
           ]
         },
         "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+          "$ref": "#/definitions/body"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -400,13 +400,9 @@
         }
       ]
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
     },
     "change_history": {
       "type": "array",
@@ -455,7 +451,7 @@
           ]
         },
         "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+          "$ref": "#/definitions/body"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
@@ -696,25 +692,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "content": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          }
-        }
-      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -188,13 +188,9 @@
         }
       ]
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
     },
     "description_optional": {
       "anyOf": [
@@ -222,7 +218,7 @@
           ]
         },
         "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+          "$ref": "#/definitions/body"
         },
         "role_payment_type": {
           "type": [
@@ -321,25 +317,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "content": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          }
-        }
-      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/formats/person.jsonnet
+++ b/formats/person.jsonnet
@@ -9,7 +9,7 @@
           "$ref": "#/definitions/analytics_identifier",
         },
         body: {
-          "$ref": "#/definitions/body_html_and_govspeak",
+          "$ref": "#/definitions/body",
         },
         full_name: {
           type: "string",

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -21,7 +21,7 @@
       additionalProperties: false,
       properties: {
         body: {
-          "$ref": "#/definitions/body_html_and_govspeak",
+          "$ref": "#/definitions/body",
         },
         attends_cabinet_type: {
           type: [


### PR DESCRIPTION
This simplifies the schema to include just the HTML for the body rather than different content types.

This matches many other content items.

[Trello Card](https://trello.com/c/evPuXJDW/1525-render-govspeak-in-person-and-roles-content-items)