### PR TITLE
Add chief_scientific_advisor_role

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -50,6 +50,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -76,6 +76,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -60,6 +60,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -50,6 +50,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -76,6 +76,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -60,6 +60,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -50,6 +50,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -76,6 +76,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -60,6 +60,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -37,6 +37,7 @@
         "ambassador_role",
         "board_member_role",
         "chief_professional_officer_role",
+        "chief_scientific_advisor_role",
         "chief_scientific_officer_role",
         "deputy_head_of_mission_role",
         "governor_role",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -63,6 +63,7 @@
         "ambassador_role",
         "board_member_role",
         "chief_professional_officer_role",
+        "chief_scientific_advisor_role",
         "chief_scientific_officer_role",
         "deputy_head_of_mission_role",
         "governor_role",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -45,6 +45,7 @@
         "ambassador_role",
         "board_member_role",
         "chief_professional_officer_role",
+        "chief_scientific_advisor_role",
         "chief_scientific_officer_role",
         "deputy_head_of_mission_role",
         "governor_role",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -53,6 +53,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -79,6 +79,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -60,6 +60,7 @@
         "case_study",
         "chief_professional_officer_role",
         "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
         "closed_consultation",
         "cma_case",
         "coming_soon",

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -3,6 +3,7 @@
     "ambassador_role",
     "board_member_role",
     "chief_professional_officer_role",
+    "chief_scientific_advisor_role",
     "chief_scientific_officer_role",
     "deputy_head_of_mission_role",
     "governor_role",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -14,6 +14,7 @@
 - case_study
 - chief_professional_officer_role
 - chief_scientific_officer_role
+- chief_scientific_advisor_role
 - closed_consultation
 - cma_case
 - coming_soon


### PR DESCRIPTION
This is a type of Role in Whitehall so we need to support it in the Publishing Platform: https://github.com/alphagov/whitehall/blob/master/app/models/chief_scientific_advisor_role.rb

If not, client will see errors like this:

```
[{"schema":{"scheme":null,"user":null,"password":null,"host":null,"port":null,"path":"e29a5603-3a91-513e-9973-e93805f4ea89","query":null,"fragment":null},"fragment":"#/document_type","message":"The property '#/document_type' value \"chief_scientific_advisor_role\" did not match one of the following values: ambassador_role, board_member_role, chief_professional_officer_role, chief_scientific_officer_role, deputy_head_of_mission_role, governor_role, high_commissioner_role, military_role, ministerial_role, special_representative_role, traffic_commissioner_role, worldwide_office_staff_role in schema e29a5603-3a91-513e-9973-e93805f4ea89","failed_attribute":"Enum"}]
```

[Trello Card](https://trello.com/c/1V8xiZUl/1529-add-chief-scientific-advisor-role-2)