### PR TITLE
Add more fields to role appointments

### DIFF
--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -303,12 +303,18 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "current": {
+          "type": "boolean"
+        },
         "ended_on": {
           "type": [
             "string",
             "null"
           ],
           "format": "date-time"
+        },
+        "person_appointment_order": {
+          "type": "integer"
         },
         "started_on": {
           "type": "string",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -423,12 +423,18 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "current": {
+          "type": "boolean"
+        },
         "ended_on": {
           "type": [
             "string",
             "null"
           ],
           "format": "date-time"
+        },
+        "person_appointment_order": {
+          "type": "integer"
         },
         "started_on": {
           "type": "string",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -186,12 +186,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "current": {
+          "type": "boolean"
+        },
         "ended_on": {
           "type": [
             "string",
             "null"
           ],
           "format": "date-time"
+        },
+        "person_appointment_order": {
+          "type": "integer"
         },
         "started_on": {
           "type": "string",

--- a/formats/role_appointment.jsonnet
+++ b/formats/role_appointment.jsonnet
@@ -22,6 +22,9 @@
         current: {
           type: "boolean"
         },
+        person_appointment_order: {
+          type: "integer"
+        }
       },
     },
   },

--- a/formats/role_appointment.jsonnet
+++ b/formats/role_appointment.jsonnet
@@ -19,6 +19,9 @@
           ],
           format: "date-time",
         },
+        current: {
+          type: "boolean"
+        },
       },
     },
   },


### PR DESCRIPTION
This adds two new fields to role appointments to support the new reverse links. This came out of comments on https://github.com/alphagov/publishing-api/pull/1645.

#### `current`

This will be set to true if the role appointment is "current". Another way of finding this out is to look at whether then `ended_on` field is set, but I thought it would be good to pull this out as denormalised data to simplify the logic of the frontends.

#### `person_importance_ordering`

This is a new field on role appointments which can be used to order appointments with the same `started_on` date by "importance".

This is used to order the appointments in some places on the frontend, notably the title which gets shown above the name of the person.

An alternative to putting this into the role appointment would be a field in the person, but that adds a dependency between the person and the role appointment meaning that if a new role appointment is created, a new edition of a person would need to be drafted to include the new role appointment in the details.

I struggling come up with a name for this field so any suggestions are welcome.

[Trello Card](https://trello.com/c/roHfuPUV/1362-8-use-reverse-links-for-role-appointments)