### PR TITLE
Remove old role appointment links

### DIFF
--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -95,14 +95,6 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_current_appointments": {
-          "description": "Roles that are currently assigned to this person.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_previous_appointments": {
-          "description": "Roles that were previously assigned to this person.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -115,14 +115,6 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_current_appointments": {
-          "description": "Roles that are currently assigned to this person.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_previous_appointments": {
-          "description": "Roles that were previously assigned to this person.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -227,14 +219,6 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_current_appointments": {
-          "description": "Roles that are currently assigned to this person.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_previous_appointments": {
-          "description": "Roles that were previously assigned to this person.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -59,14 +59,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ordered_current_appointments": {
-          "description": "Roles that are currently assigned to this person.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_previous_appointments": {
-          "description": "Roles that were previously assigned to this person.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -107,16 +107,8 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_current_appointments": {
-          "description": "People who are currently assigned to this role.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_previous_appointments": {
-          "description": "People who were previously assigned to this role.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_related_items": {

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -127,16 +127,8 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_current_appointments": {
-          "description": "People who are currently assigned to this role.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_previous_appointments": {
-          "description": "People who were previously assigned to this role.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_related_items": {
@@ -245,16 +237,8 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "ordered_current_appointments": {
-          "description": "People who are currently assigned to this role.",
-          "$ref": "#/definitions/guid_list"
-        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_previous_appointments": {
-          "description": "People who were previously assigned to this role.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -69,16 +69,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ordered_current_appointments": {
-          "description": "People who are currently assigned to this role.",
-          "$ref": "#/definitions/guid_list"
-        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_previous_appointments": {
-          "description": "People who were previously assigned to this role.",
           "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {

--- a/formats/person.jsonnet
+++ b/formats/person.jsonnet
@@ -27,8 +27,4 @@
       },
     },
   },
-  edition_links: (import "shared/base_edition_links.jsonnet") + {
-    ordered_current_appointments: "Roles that are currently assigned to this person.",
-    ordered_previous_appointments: "Roles that were previously assigned to this person.",
-  },
 }

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -54,7 +54,5 @@
   },
   edition_links: (import "shared/base_edition_links.jsonnet") + {
     ordered_parent_organisations: "Organisations that own this role.",
-    ordered_current_appointments: "People who are currently assigned to this role.",
-    ordered_previous_appointments: "People who were previously assigned to this role.",
   },
 }


### PR DESCRIPTION
All the people and roles have been republished from Whitehall now so the links no longer exist. Instead we can use the reverse links put in my the Publishing API.

See alphagov/publishing-api#1645 for more information.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)