### PR TITLE
Max 1 government

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -81,7 +81,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -101,7 +101,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -224,7 +225,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -84,7 +84,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -104,7 +104,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -232,7 +233,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -64,7 +64,8 @@
       "properties": {
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "ministers": {
           "description": "Deprecated. These are relations to minister people pages, this is superseded by 'people'",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -104,7 +104,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -124,7 +124,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -241,7 +242,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -27,7 +27,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -84,7 +84,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -82,7 +82,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -102,7 +102,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -225,7 +226,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -84,7 +84,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -104,7 +104,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -229,7 +230,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -27,7 +27,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -64,7 +64,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "organisations": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -84,7 +84,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -104,7 +104,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -245,7 +246,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -64,7 +64,8 @@
       "properties": {
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -100,7 +100,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -120,7 +120,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -254,7 +255,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -80,7 +80,8 @@
       "properties": {
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "ministers": {
           "description": "Deprecated. These are relations to minister people pages, this is superseded by 'people'",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -84,7 +84,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -104,7 +104,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -244,7 +245,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -81,7 +81,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -101,7 +101,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -224,7 +225,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -24,7 +24,8 @@
         },
         "government": {
           "description": "The government associated with this document",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/formats/case_study.jsonnet
+++ b/formats/case_study.jsonnet
@@ -48,7 +48,10 @@
     },
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     related_policies: "",
     world_locations: "",
     worldwide_organisations: "",

--- a/formats/consultation.jsonnet
+++ b/formats/consultation.jsonnet
@@ -98,13 +98,15 @@
     },
   },
   edition_links: (import "shared/whitehall_edition_links.jsonnet") + {
-    government: "The government associated with this document",
     ministers: "Deprecated. These are relations to minister people pages, this is superseded by 'people'",
     people: "People that are associated with this document, typically the person part of a role association",
     roles: "Government roles that are associated with this document, typically the role part of a role association",
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     related_policies: "",
     ministers: "Deprecated. These are relations to minister people pages, this is superseded by 'people'",
     topical_events: "",

--- a/formats/corporate_information_page.jsonnet
+++ b/formats/corporate_information_page.jsonnet
@@ -53,7 +53,10 @@
   },
   edition_links: {
     corporate_information_pages: "",
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     organisations: "All organisations linked to this content item. This should include lead organisations.",
     parent: {
       description: "The parent content item.",
@@ -67,6 +70,9 @@
   },
   links: (import "shared/base_links.jsonnet") + {
     corporate_information_pages: "",
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
   },
 }

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -60,7 +60,10 @@
     },
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     related_guides: "",
     related_policies: "",
     related_mainstream_content: "",

--- a/formats/document_collection.jsonnet
+++ b/formats/document_collection.jsonnet
@@ -63,11 +63,13 @@
     },
   },
   edition_links: (import "shared/whitehall_edition_links.jsonnet") + {
-    government: "The government associated with this document",
     documents: "",
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     related_guides: "",
     related_policies: "",
     related_mainstream_content: "",

--- a/formats/news_article.jsonnet
+++ b/formats/news_article.jsonnet
@@ -41,7 +41,10 @@
     },
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     related_policies: "",
     ministers: "Deprecated. These are relations to minister people pages, this is superseded by 'people'",
     topical_events: "The topical events this content item relates to.",
@@ -51,7 +54,10 @@
     people: "People that are associated with this document, typically the person part of a role association",
   },
   edition_links: (import "shared/base_edition_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     roles: "Government roles that are associated with this document, typically the role part of a role association",
     people: "People that are associated with this document, typically the person part of a role association",
     topical_events: "The topical events this content item relates to.",

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -63,7 +63,6 @@
     },
   },
   edition_links: (import "shared/whitehall_edition_links.jsonnet") + {
-    government: "The government associated with this document",
     ministers: "Deprecated. These are relations to minister people pages, this is superseded by 'people'",
     people: "People that are associated with this document, typically the person part of a role association",
     related_statistical_data_sets: "",
@@ -71,7 +70,10 @@
     world_locations: "",
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     ministers: "Deprecated. These are relations to minister people pages, this is superseded by 'people'",
     related_policies: "",
     related_statistical_data_sets: "",

--- a/formats/shared/whitehall_edition_links.jsonnet
+++ b/formats/shared/whitehall_edition_links.jsonnet
@@ -1,4 +1,8 @@
 (import "base_edition_links.jsonnet") + {
+  government: {
+    description: "The government associated with this document",
+    maxItems: 1,
+  },
   organisations: "",
   parent: "",
   primary_publishing_organisation: {

--- a/formats/speech.jsonnet
+++ b/formats/speech.jsonnet
@@ -59,7 +59,10 @@
     },
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     speaker: {
       description: "A speaker that has a GOV.UK profile",
       maxItems: 1,

--- a/formats/world_location_news_article.jsonnet
+++ b/formats/world_location_news_article.jsonnet
@@ -35,7 +35,10 @@
     },
   },
   links: (import "shared/base_links.jsonnet") + {
-    government: "The government associated with this document",
+    government: {
+      description: "The government associated with this document",
+      maxItems: 1,
+    },
     topical_events: "",
     worldwide_organisations: "",
     world_locations: "",


### PR DESCRIPTION
The government association is used to indicate that content was
published under the time of a government. As our system doesn't allow
the possibility of 2 governments serving at the same time (and hopefully
neither does the monarchy) this should never be more than a single item.

I did wonder if it would be better to set government as an item on base links
rather than changing them for each document type but I didn't want to
introduce more changes than necessary in this PR as I know this work
is rather time critical.