### PR TITLE
Add document_type property to finder email signup schema

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -390,6 +390,9 @@
             "content_purpose_supergroup": {
               "type": "string"
             },
+            "document_type": {
+              "type": "string"
+            },
             "part_of_taxonomy_tree": {
               "type": "string"
             }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -494,6 +494,9 @@
             "content_purpose_supergroup": {
               "type": "string"
             },
+            "document_type": {
+              "type": "string"
+            },
             "part_of_taxonomy_tree": {
               "type": "string"
             }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -264,6 +264,9 @@
             "content_purpose_supergroup": {
               "type": "string"
             },
+            "document_type": {
+              "type": "string"
+            },
             "part_of_taxonomy_tree": {
               "type": "string"
             }

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -171,6 +171,9 @@
             part_of_taxonomy_tree: {
               type: "string"
             },
+            document_type: {
+              type: "string"
+            },
           },
         },
         reject: {


### PR DESCRIPTION
This updated the finder email signup schema to enable users to subscribe to email alerts for updates made across a document type.

Content store document type will typically be used as a default email filter by specialist finders in the case that the user has selected no specific email filter facets.

Related to https://github.com/alphagov/specialist-publisher/pull/1540

https://trello.com/c/OPAcIhIF/1193-cannot-sign-up-to-email-alerts-when-no-facets-are-selected