### PR TITLE
Add political status to organisations schema

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -653,6 +653,10 @@
             "tribunal"
           ]
         },
+        "political": {
+          "description": "Political status of the organisation used for history mode",
+          "type": "boolean"
+        },
         "secondary_corporate_information_pages": {
           "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
           "type": "string"

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -787,6 +787,10 @@
             "tribunal"
           ]
         },
+        "political": {
+          "description": "Political status of the organisation used for history mode",
+          "type": "boolean"
+        },
         "secondary_corporate_information_pages": {
           "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
           "type": "string"

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -529,6 +529,10 @@
             "tribunal"
           ]
         },
+        "political": {
+          "description": "Political status of the organisation used for history mode",
+          "type": "boolean"
+        },
         "secondary_corporate_information_pages": {
           "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
           "type": "string"

--- a/examples/organisation/frontend/organisation.json
+++ b/examples/organisation/frontend/organisation.json
@@ -172,6 +172,7 @@
       "status": "live"
     },
     "organisation_type": "ministerial_department",
+    "political": true,
     "social_media_links": [
       {
         "service_type": "twitter",

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -318,6 +318,10 @@
           ],
           description: "The type of organisation.",
         },
+        "political": {
+          "description": "Political status of the organisation used for history mode",
+          "type": "boolean"
+        },
         social_media_links: {
           type: "array",
           items: {


### PR DESCRIPTION
We want to present organisations political status from Whitehall to Publishing
API so we can use this information in Content Publisher. It is currently
hardcoded in the YAML file and requires manual updates.

[Trello card](https://trello.com/c/zHm2B8VX/1242-present-organisation-political-status-from-whitehall-to-publishing-api)