### PR TITLE
Deprecate government in details body

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -563,6 +563,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -684,6 +684,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -352,6 +352,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -512,6 +512,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -628,6 +628,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -265,6 +265,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -519,6 +519,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -637,6 +637,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -302,6 +302,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -511,6 +511,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -645,6 +645,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -280,6 +280,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -534,6 +534,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -661,6 +661,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -323,6 +323,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -528,6 +528,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -661,6 +661,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -264,6 +264,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -479,6 +479,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -585,6 +585,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -251,6 +251,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -482,6 +482,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -598,6 +598,7 @@
       }
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -235,6 +235,7 @@
       "format": "date-time"
     },
     "government": {
+      "description": "DEPRECATED: Content should be associated with a government through a link",
       "type": "object",
       "required": [
         "title",

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -2,6 +2,7 @@
   government: {
     type: "object",
     additionalProperties: false,
+    description: "DEPRECATED: Content should be associated with a government through a link",
     required: [
       "title",
       "slug",


### PR DESCRIPTION
Since https://github.com/alphagov/govuk-content-schemas/pull/936 we are switching the GOV.UK stack to use links to share government information rather than the details attribute.

With the preference for this the government information in the details will slowly slip out of date and thus should not be used.