### PR TITLE
Rename political to organisation_political

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -632,6 +632,10 @@
             }
           }
         },
+        "organisation_political": {
+          "description": "Determines whether content published by this organisation represents governments policies and can be eligible for history mode",
+          "type": "boolean"
+        },
         "organisation_type": {
           "description": "The type of organisation.",
           "type": "string",
@@ -652,10 +656,6 @@
             "sub_organisation",
             "tribunal"
           ]
-        },
-        "political": {
-          "description": "Political status of the organisation used for history mode",
-          "type": "boolean"
         },
         "secondary_corporate_information_pages": {
           "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -766,6 +766,10 @@
             }
           }
         },
+        "organisation_political": {
+          "description": "Determines whether content published by this organisation represents governments policies and can be eligible for history mode",
+          "type": "boolean"
+        },
         "organisation_type": {
           "description": "The type of organisation.",
           "type": "string",
@@ -786,10 +790,6 @@
             "sub_organisation",
             "tribunal"
           ]
-        },
-        "political": {
-          "description": "Political status of the organisation used for history mode",
-          "type": "boolean"
         },
         "secondary_corporate_information_pages": {
           "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -508,6 +508,10 @@
             }
           }
         },
+        "organisation_political": {
+          "description": "Determines whether content published by this organisation represents governments policies and can be eligible for history mode",
+          "type": "boolean"
+        },
         "organisation_type": {
           "description": "The type of organisation.",
           "type": "string",
@@ -528,10 +532,6 @@
             "sub_organisation",
             "tribunal"
           ]
-        },
-        "political": {
-          "description": "Political status of the organisation used for history mode",
-          "type": "boolean"
         },
         "secondary_corporate_information_pages": {
           "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",

--- a/examples/organisation/frontend/organisation.json
+++ b/examples/organisation/frontend/organisation.json
@@ -172,7 +172,7 @@
       "status": "live"
     },
     "organisation_type": "ministerial_department",
-    "political": true,
+    "organisation_political": true,
     "social_media_links": [
       {
         "service_type": "twitter",

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -318,8 +318,8 @@
           ],
           description: "The type of organisation.",
         },
-        "political": {
-          "description": "Political status of the organisation used for history mode",
+        "organisation_political": {
+          "description": "Determines whether content published by this organisation represents governments policies and can be eligible for history mode",
           "type": "boolean"
         },
         social_media_links: {


### PR DESCRIPTION
Renamed due to 'political' already in use and an overloaded term.

[Trello card](https://trello.com/c/zHm2B8VX/1242-present-organisation-political-status-from-whitehall-to-publishing-api)