### PR TITLE
Add new Tenant Fees Act category

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2308,7 +2308,8 @@
             "park-homes",
             "rents",
             "right-to-buy",
-            "tenant-associations"
+            "tenant-associations",
+            "tenant-fees-act"
           ]
         },
         "tribunal_decision_decision_date": {
@@ -2361,7 +2362,9 @@
             "rents---fair-rent",
             "right-to-buy---right-to-buy-appeals-elderly-persons",
             "tenant-associations---recognition-of-tenants-association",
-            "tenant-associations---request-for-information"
+            "tenant-associations---request-for-information",
+            "tenant-fees-act---recovery-of-a-prohibited-payment",
+            "tenant-fees-act---financial-penalties"
           ]
         }
       }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2442,7 +2442,8 @@
             "park-homes",
             "rents",
             "right-to-buy",
-            "tenant-associations"
+            "tenant-associations",
+            "tenant-fees-act"
           ]
         },
         "tribunal_decision_decision_date": {
@@ -2495,7 +2496,9 @@
             "rents---fair-rent",
             "right-to-buy---right-to-buy-appeals-elderly-persons",
             "tenant-associations---recognition-of-tenants-association",
-            "tenant-associations---request-for-information"
+            "tenant-associations---request-for-information",
+            "tenant-fees-act---recovery-of-a-prohibited-payment",
+            "tenant-fees-act---financial-penalties"
           ]
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2098,7 +2098,8 @@
             "park-homes",
             "rents",
             "right-to-buy",
-            "tenant-associations"
+            "tenant-associations",
+            "tenant-fees-act"
           ]
         },
         "tribunal_decision_decision_date": {
@@ -2151,7 +2152,9 @@
             "rents---fair-rent",
             "right-to-buy---right-to-buy-appeals-elderly-persons",
             "tenant-associations---recognition-of-tenants-association",
-            "tenant-associations---request-for-information"
+            "tenant-associations---request-for-information",
+            "tenant-fees-act---recovery-of-a-prohibited-payment",
+            "tenant-fees-act---financial-penalties"
           ]
         }
       }

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1903,7 +1903,8 @@
           "park-homes",
           "rents",
           "right-to-buy",
-          "tenant-associations"
+          "tenant-associations",
+          "tenant-fees-act"
         ],
       },
       tribunal_decision_sub_category: {
@@ -1952,7 +1953,9 @@
           "rents---fair-rent",
           "right-to-buy---right-to-buy-appeals-elderly-persons",
           "tenant-associations---recognition-of-tenants-association",
-          "tenant-associations---request-for-information"
+          "tenant-associations---request-for-information",
+          "tenant-fees-act---recovery-of-a-prohibited-payment",
+          "tenant-fees-act---financial-penalties"
         ],
       },
       tribunal_decision_decision_date: {


### PR DESCRIPTION
Trello: https://govuk.zendesk.com/agent/tickets/3867807
Related to: https://github.com/alphagov/specialist-publisher/pull/1546

Adds a new Tennant Fees Act category and sub-categories to the residential property finder