### PR TITLE
Remove finder email signup keys

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -361,19 +361,6 @@
             }
           }
         },
-        "email_filter_name": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/facet_name"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "email_signup_choice": {
-          "$ref": "#/definitions/facet_choices"
-        },
         "filter": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -465,19 +465,6 @@
             }
           }
         },
-        "email_filter_name": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/facet_name"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "email_signup_choice": {
-          "$ref": "#/definitions/facet_choices"
-        },
         "filter": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -235,19 +235,6 @@
             }
           }
         },
-        "email_filter_name": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/facet_name"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "email_signup_choice": {
-          "$ref": "#/definitions/facet_choices"
-        },
         "filter": {
           "type": "object",
           "additionalProperties": false,

--- a/examples/finder_email_signup/frontend/cma-cases-email-signup.json
+++ b/examples/finder_email_signup/frontend/cma-cases-email-signup.json
@@ -76,55 +76,57 @@
   "description": "You'll get an email each time a case is updated or a new case is published.",
   "details": {
     "beta": false,
-    "email_signup_choice": [
+    "email_filter_facets": [
       {
-        "key": "ca98-and-civil-cartels",
-        "radio_button_name": "CA98 and civil cartels",
-        "topic_name": "CA98 and civil cartels",
-        "prechecked": false
-      },
-      {
-        "key": "criminal-cartels",
-        "radio_button_name": "Criminal cartels",
-        "topic_name": "criminal cartels",
-        "prechecked": false
-      },
-      {
-        "key": "markets",
-        "radio_button_name": "Markets",
-        "topic_name": "markets",
-        "prechecked": false
-      },
-      {
-        "key": "mergers",
-        "radio_button_name": "Mergers",
-        "topic_name": "mergers",
-        "prechecked": false
-      },
-      {
-        "key": "consumer-enforcement",
-        "radio_button_name": "Consumer enforcement",
-        "topic_name": "consumer enforcement",
-        "prechecked": false
-      },
-      {
-        "key": "regulatory-references-and-appeals",
-        "radio_button_name": "Regulatory references and appeals",
-        "topic_name": "regulatory references and appeals",
-        "prechecked": false
-      },
-      {
-        "key": "review-of-orders-and-undertakings",
-        "radio_button_name": "Reviews of orders and undertakings",
-        "topic_name": "reviews of orders and undertakings",
-        "prechecked": false
+        "facet_id": "case_type",
+        "facet_name": "Case type",
+        "facet_choices": [
+          {
+            "key": "ca98-and-civil-cartels",
+            "radio_button_name": "CA98 and civil cartels",
+            "topic_name": "CA98 and civil cartels",
+            "prechecked": false
+          },
+          {
+            "key": "criminal-cartels",
+            "radio_button_name": "Criminal cartels",
+            "topic_name": "criminal cartels",
+            "prechecked": false
+          },
+          {
+            "key": "markets",
+            "radio_button_name": "Markets",
+            "topic_name": "markets",
+            "prechecked": false
+          },
+          {
+            "key": "mergers",
+            "radio_button_name": "Mergers",
+            "topic_name": "mergers",
+            "prechecked": false
+          },
+          {
+            "key": "consumer-enforcement",
+            "radio_button_name": "Consumer enforcement",
+            "topic_name": "consumer enforcement",
+            "prechecked": false
+          },
+          {
+            "key": "regulatory-references-and-appeals",
+            "radio_button_name": "Regulatory references and appeals",
+            "topic_name": "regulatory references and appeals",
+            "prechecked": false
+          },
+          {
+            "key": "review-of-orders-and-undertakings",
+            "radio_button_name": "Reviews of orders and undertakings",
+            "topic_name": "reviews of orders and undertakings",
+            "prechecked": false
+          }
+        ]
       }
     ],
     "email_filter_by": "case_type",
-    "email_filter_name": {
-      "singular": "case type",
-      "plural": "case types"
-    },
     "subscription_list_title_prefix": {
       "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
       "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",

--- a/examples/finder_email_signup/frontend/news-and-communications-email-signup.json
+++ b/examples/finder_email_signup/frontend/news-and-communications-email-signup.json
@@ -46,7 +46,6 @@
       ]
     },
     "email_filter_by": null,
-    "email_filter_name": null,
     "subscription_list_title_prefix": "News and communications ",
     "email_filter_facets": [
       {

--- a/examples/finder_email_signup/frontend/raib-report-email-signup.json
+++ b/examples/finder_email_signup/frontend/raib-report-email-signup.json
@@ -65,37 +65,39 @@
   "description": "You'll get an email each time a report is updated or a new report is published.",
   "details": {
     "beta": false,
-    "email_signup_choice": [
+    "email_filter_facets": [
       {
-        "key": "heavy-rail",
-        "radio_button_name": "Heavy rail",
-        "topic_name": "heavy rail",
-        "prechecked": false
-      },
-      {
-        "key": "light-rail",
-        "radio_button_name": "Light rail",
-        "topic_name": "light rail",
-        "prechecked": false
-      },
-      {
-        "key": "metros",
-        "radio_button_name": "Metros",
-        "topic_name": "metros",
-        "prechecked": false
-      },
-      {
-        "key": "heritage-railways",
-        "radio_button_name": "Heritage railways",
-        "topic_name": "heritage railways",
-        "prechecked": false
+        "facet_id": "railway_type",
+        "facet_name": "Railway types",
+        "facet_choices": [
+          {
+            "key": "heavy-rail",
+            "radio_button_name": "Heavy rail",
+            "topic_name": "heavy rail",
+            "prechecked": false
+          },
+          {
+            "key": "light-rail",
+            "radio_button_name": "Light rail",
+            "topic_name": "light rail",
+            "prechecked": false
+          },
+          {
+            "key": "metros",
+            "radio_button_name": "Metros",
+            "topic_name": "metros",
+            "prechecked": false
+          },
+          {
+            "key": "heritage-railways",
+            "radio_button_name": "Heritage railways",
+            "topic_name": "heritage railways",
+            "prechecked": false
+          }
+        ]
       }
     ],
     "email_filter_by": "railway_type",
-    "email_filter_name": {
-      "singular": "railway type",
-      "plural": "railway types"
-    },
     "subscription_list_title_prefix": {
       "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",
       "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: ",

--- a/examples/finder_email_signup/publisher_v2/finder_email_signup.json
+++ b/examples/finder_email_signup/publisher_v2/finder_email_signup.json
@@ -18,57 +18,59 @@
   "details": {
     "beta": false,
     "email_filter_by": "case_type",
-    "email_filter_name": {
-      "singular": "case type",
-      "plural": "case types"
-    },
     "subscription_list_title_prefix": {
       "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
       "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
       "many": "Competition and Markets Authority (CMA) cases: "
     },
-    "email_signup_choice": [
+    "email_filter_facets": [
       {
-        "key": "ca98-and-civil-cartels",
-        "prechecked": false,
-        "radio_button_name": "CA98 and civil cartels",
-        "topic_name": "CA98 and civil cartels"
-      },
-      {
-        "key": "criminal-cartels",
-        "prechecked": false,
-        "radio_button_name": "Criminal cartels",
-        "topic_name": "criminal cartels"
-      },
-      {
-        "key": "markets",
-        "prechecked": false,
-        "radio_button_name": "Markets",
-        "topic_name": "markets"
-      },
-      {
-        "key": "mergers",
-        "prechecked": false,
-        "radio_button_name": "Mergers",
-        "topic_name": "mergers"
-      },
-      {
-        "key": "consumer-enforcement",
-        "prechecked": false,
-        "radio_button_name": "Consumer enforcement",
-        "topic_name": "consumer enforcement"
-      },
-      {
-        "key": "regulatory-references-and-appeals",
-        "prechecked": false,
-        "radio_button_name": "Regulatory references and appeals",
-        "topic_name": "regulatory references and appeals"
-      },
-      {
-        "key": "review-of-orders-and-undertakings",
-        "prechecked": false,
-        "radio_button_name": "Reviews of orders and undertakings",
-        "topic_name": "reviews of orders and undertakings"
+        "facet_id": "case_type",
+        "facet_name": "Case types",
+        "facet_choices": [
+          {
+            "key": "ca98-and-civil-cartels",
+            "prechecked": false,
+            "radio_button_name": "CA98 and civil cartels",
+            "topic_name": "CA98 and civil cartels"
+          },
+          {
+            "key": "criminal-cartels",
+            "prechecked": false,
+            "radio_button_name": "Criminal cartels",
+            "topic_name": "criminal cartels"
+          },
+          {
+            "key": "markets",
+            "prechecked": false,
+            "radio_button_name": "Markets",
+            "topic_name": "markets"
+          },
+          {
+            "key": "mergers",
+            "prechecked": false,
+            "radio_button_name": "Mergers",
+            "topic_name": "mergers"
+          },
+          {
+            "key": "consumer-enforcement",
+            "prechecked": false,
+            "radio_button_name": "Consumer enforcement",
+            "topic_name": "consumer enforcement"
+          },
+          {
+            "key": "regulatory-references-and-appeals",
+            "prechecked": false,
+            "radio_button_name": "Regulatory references and appeals",
+            "topic_name": "regulatory references and appeals"
+          },
+          {
+            "key": "review-of-orders-and-undertakings",
+            "prechecked": false,
+            "radio_button_name": "Reviews of orders and undertakings",
+            "topic_name": "reviews of orders and undertakings"
+          }
+        ]
       }
     ]
   }

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -86,19 +86,6 @@
         beta: {
           "$ref": "#/definitions/finder_beta",
         },
-        email_signup_choice: {
-          "$ref": "#/definitions/facet_choices",
-        },
-        email_filter_name: {
-          oneOf: [
-            {
-              "$ref": "#/definitions/facet_name"
-            },
-            {
-              type: "null",
-            },
-          ]
-        },
         email_filter_by: {
           oneOf: [
             {


### PR DESCRIPTION
These fields are no longer be used by finder-frontend or specialist publisher so can be removed from the schemas.

This PR depended on these PRs being merged and deployed (done):

- https://github.com/alphagov/specialist-publisher/pull/1555
- https://github.com/alphagov/finder-frontend/pull/1831

https://trello.com/c/otcTG22f/1246-email-alert-signup-tech-debt