### PR TITLE
Add brexit no deal notice

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -275,6 +275,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -327,6 +347,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -391,6 +391,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -443,6 +463,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -161,6 +161,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -213,6 +233,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -276,6 +276,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -327,6 +347,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -392,6 +392,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -443,6 +463,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -162,6 +162,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -213,6 +233,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -277,6 +277,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -319,6 +339,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -395,6 +395,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -437,6 +457,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -193,6 +193,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -235,6 +255,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -258,6 +258,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -300,6 +320,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -357,6 +357,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -399,6 +419,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -176,6 +176,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "description_optional": {
       "anyOf": [
         {
@@ -197,6 +217,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "first_published_version": {
           "type": "boolean"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -313,6 +313,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -356,6 +376,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -440,6 +440,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -483,6 +503,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -235,6 +235,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_no_deal_notice": {
+      "description": "A list of URLs and titles for a brexit no deal notice.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -278,6 +298,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_no_deal_notice": {
+          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/formats/case_study.jsonnet
+++ b/formats/case_study.jsonnet
@@ -44,6 +44,9 @@
         emphasised_organisations: {
           "$ref": "#/definitions/emphasised_organisations",
         },
+        brexit_no_deal_notice: {
+          "$ref": "#/definitions/brexit_no_deal_notice",
+        }
       },
     },
   },

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -56,6 +56,9 @@
         national_applicability: {
           "$ref": "#/definitions/national_applicability",
         },
+        brexit_no_deal_notice: {
+          "$ref": "#/definitions/brexit_no_deal_notice",
+        }
       },
     },
   },

--- a/formats/document_collection.jsonnet
+++ b/formats/document_collection.jsonnet
@@ -59,6 +59,9 @@
         emphasised_organisations: {
           "$ref": "#/definitions/emphasised_organisations",
         },
+        brexit_no_deal_notice: {
+          "$ref": "#/definitions/brexit_no_deal_notice",
+        }
       },
     },
   },

--- a/formats/html_publication.jsonnet
+++ b/formats/html_publication.jsonnet
@@ -1,6 +1,6 @@
 (import "shared/default_format.jsonnet") + {
   document_type: "html_publication",
-  definitions: {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
     details: {
       type: "object",
       additionalProperties: false,
@@ -36,6 +36,9 @@
           type: "string",
           description: "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication",
         },
+        brexit_no_deal_notice: {
+          "$ref": "#/definitions/brexit_no_deal_notice",
+        }
       },
     },
   },

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -59,6 +59,9 @@
         national_applicability: {
           "$ref": "#/definitions/national_applicability",
         },
+        brexit_no_deal_notice: {
+          "$ref": "#/definitions/brexit_no_deal_notice",
+        }
       },
     },
   },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -330,4 +330,24 @@
     type: "string",
     format: "date-time",
   },
+  brexit_no_deal_notice: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+      },
+    },
+    description: "A list of URLs and titles for a brexit no deal notice.",
+  }
 }


### PR DESCRIPTION
Adds the possibility to add a notice to Whitehall content explaining where updated content is.

The links can be external or internal. A title has to be provided for each link.

https://trello.com/c/0URepvoe/270-update-whitehall-content-schema-to-include-a-no-deal-notice