### PR TITLE
Remove hide facets by default field

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -347,9 +347,6 @@
         "generic_description": {
           "type": "boolean"
         },
-        "hide_facets_by_default": {
-          "$ref": "#/definitions/finder_hide_facets_by_default"
-        },
         "logo_path": {
           "type": "string"
         },
@@ -577,10 +574,6 @@
           }
         }
       }
-    },
-    "finder_hide_facets_by_default": {
-      "description": "Specify this to hide most of the facets behind a toggle on desktop",
-      "type": "boolean"
     },
     "finder_reject_filter": {
       "description": "A fixed filter that rejects documents which match the conditions",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -463,9 +463,6 @@
         "generic_description": {
           "type": "boolean"
         },
-        "hide_facets_by_default": {
-          "$ref": "#/definitions/finder_hide_facets_by_default"
-        },
         "logo_path": {
           "type": "string"
         },
@@ -693,10 +690,6 @@
           }
         }
       }
-    },
-    "finder_hide_facets_by_default": {
-      "description": "Specify this to hide most of the facets behind a toggle on desktop",
-      "type": "boolean"
     },
     "finder_reject_filter": {
       "description": "A fixed filter that rejects documents which match the conditions",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -213,9 +213,6 @@
         "generic_description": {
           "type": "boolean"
         },
-        "hide_facets_by_default": {
-          "$ref": "#/definitions/finder_hide_facets_by_default"
-        },
         "logo_path": {
           "type": "string"
         },
@@ -443,10 +440,6 @@
           }
         }
       }
-    },
-    "finder_hide_facets_by_default": {
-      "description": "Specify this to hide most of the facets behind a toggle on desktop",
-      "type": "boolean"
     },
     "finder_reject_filter": {
       "description": "A fixed filter that rejects documents which match the conditions",

--- a/examples/finder/frontend/all_content.json
+++ b/examples/finder/frontend/all_content.json
@@ -11,7 +11,6 @@
   "details": {
     "default_documents_per_page": 20,
     "document_noun": "result",
-    "hide_facets_by_default": true,
     "facets": [
       {
         "key": "topics",

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -34,9 +34,6 @@
         document_noun: {
           "$ref": "#/definitions/finder_document_noun",
         },
-        hide_facets_by_default: {
-          "$ref": "#/definitions/finder_hide_facets_by_default",
-        },
         default_documents_per_page: {
           "$ref": "#/definitions/finder_default_documents_per_page",
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -3,10 +3,6 @@
     description: "How to refer to documents when presenting the search results",
     type: "string",
   },
-  finder_hide_facets_by_default: {
-    description: "Specify this to hide most of the facets behind a toggle on desktop",
-    type: "boolean",
-  },
   finder_default_documents_per_page: {
     description: "Specify this to paginate results",
     type: "integer",


### PR DESCRIPTION
As of alphagov/search-api@1ce164d this field will no longer be used.

Should be merged and deployed after alphagov/search-api#1920 has gone out.

https://trello.com/c/PtSyQ5hi/1285-show-facets-by-default
