### PR TITLE
Add required field to email signup facets

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -357,6 +357,10 @@
                     }
                   }
                 }
+              },
+              "required": {
+                "description": "Indicates whether this facet must have a value in order for a subscriber lists to be acceptable",
+                "type": "boolean"
               }
             }
           }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -461,6 +461,10 @@
                     }
                   }
                 }
+              },
+              "required": {
+                "description": "Indicates whether this facet must have a value in order for a subscriber lists to be acceptable",
+                "type": "boolean"
               }
             }
           }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -231,6 +231,10 @@
                     }
                   }
                 }
+              },
+              "required": {
+                "description": "Indicates whether this facet must have a value in order for a subscriber lists to be acceptable",
+                "type": "boolean"
               }
             }
           }

--- a/examples/finder_email_signup/frontend/cma-cases-email-signup.json
+++ b/examples/finder_email_signup/frontend/cma-cases-email-signup.json
@@ -80,6 +80,7 @@
       {
         "facet_id": "case_type",
         "facet_name": "Case type",
+        "required": true,
         "facet_choices": [
           {
             "key": "ca98-and-civil-cartels",

--- a/examples/finder_email_signup/publisher_v2/finder_email_signup.json
+++ b/examples/finder_email_signup/publisher_v2/finder_email_signup.json
@@ -27,6 +27,7 @@
       {
         "facet_id": "case_type",
         "facet_name": "Case types",
+        "required": true,
         "facet_choices": [
           {
             "key": "ca98-and-civil-cartels",

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -120,6 +120,10 @@
               filter_value: {
                 type: "string",
               },
+              required: {
+                description: "Indicates whether this facet must have a value in order for a subscriber lists to be acceptable",
+                type: "boolean",
+              },
               option_lookup: {
                 description: "An array of key values where the key is the value of a selected facet and the value(s) are what these are converted to in a Rummager query",
                 type: "object",


### PR DESCRIPTION
The required boolean on email facets will enable us to
specify in the content item whether a facet must have a
value. This is useful for CMA cases and Research and Statistics
finder email signup content items.

https://trello.com/c/NS1ZPbBF/1249
