### PR TITLE
Add format to permitted filter fields

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -384,6 +384,9 @@
             "document_type": {
               "type": "string"
             },
+            "format": {
+              "type": "string"
+            },
             "part_of_taxonomy_tree": {
               "type": "string"
             }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -488,6 +488,9 @@
             "document_type": {
               "type": "string"
             },
+            "format": {
+              "type": "string"
+            },
             "part_of_taxonomy_tree": {
               "type": "string"
             }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -258,6 +258,9 @@
             "document_type": {
               "type": "string"
             },
+            "format": {
+              "type": "string"
+            },
             "part_of_taxonomy_tree": {
               "type": "string"
             }

--- a/examples/finder_email_signup/frontend/cma-cases-email-signup.json
+++ b/examples/finder_email_signup/frontend/cma-cases-email-signup.json
@@ -76,6 +76,9 @@
   "description": "You'll get an email each time a case is updated or a new case is published.",
   "details": {
     "beta": false,
+    "filter": {
+      "document_type": "cma_case"
+    },
     "email_filter_facets": [
       {
         "facet_id": "case_type",

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -165,6 +165,9 @@
             document_type: {
               type: "string"
             },
+            format: {
+              type: "string"
+            }
           },
         },
         reject: {


### PR DESCRIPTION
Related to https://github.com/alphagov/specialist-publisher/pull/1563

We want to permit format as a default filter in email signups.

https://trello.com/c/yLsG8ecR/1292-fix-specialist-publisher-email-signups