### PR TITLE
Remove appear_in_find_eu_exit_guidance_business_finder field

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -519,9 +519,6 @@
             "type": "string"
           }
         },
-        "appear_in_find_eu_exit_guidance_business_finder": {
-          "type": "string"
-        },
         "content_purpose_subgroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -635,9 +635,6 @@
             "type": "string"
           }
         },
-        "appear_in_find_eu_exit_guidance_business_finder": {
-          "type": "string"
-        },
         "content_purpose_subgroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -385,9 +385,6 @@
             "type": "string"
           }
         },
-        "appear_in_find_eu_exit_guidance_business_finder": {
-          "type": "string"
-        },
         "content_purpose_subgroup": {
           "type": "array",
           "items": {

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -48,9 +48,6 @@
           type: "string",
         },
       },
-      appear_in_find_eu_exit_guidance_business_finder: {
-        type: "string",
-      },
       facet_groups: {
           type: "array",
           items: {


### PR DESCRIPTION
This was initially used by the EU exit business finder, but no longer was. And the business finder has now been decommissioned anyway.