### PR TITLE
Implement backwards-compatible changes to Whitehall attachments for RFC 116

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -331,6 +331,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -346,6 +353,13 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "featured_attachments": {
+          "description": "An ordered list of attachments to feature on the page",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "final_outcome_detail": {
           "type": "string"
@@ -744,6 +758,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -452,6 +452,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -467,6 +474,13 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "featured_attachments": {
+          "description": "An ordered list of attachments to feature on the page",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "final_outcome_detail": {
           "type": "string"
@@ -832,6 +846,25 @@
         "zh-tw"
       ]
     },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",
       "type": "object",
@@ -882,6 +915,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -253,6 +253,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -268,6 +275,13 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "featured_attachments": {
+          "description": "An ordered list of attachments to feature on the page",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "final_outcome_detail": {
           "type": "string"
@@ -494,6 +508,25 @@
         "zh-tw"
       ]
     },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",
       "type": "object",
@@ -540,6 +573,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -333,6 +333,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -636,6 +643,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -443,6 +443,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -763,6 +770,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -247,6 +247,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -424,6 +431,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -345,6 +345,13 @@
         "alternative_wales_url": {
           "type": "string"
         },
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -716,6 +723,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -461,6 +461,13 @@
         "alternative_wales_url": {
           "type": "string"
         },
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -849,6 +856,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -231,6 +231,13 @@
         "alternative_wales_url": {
           "type": "string"
         },
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -476,6 +483,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -334,6 +334,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -654,6 +661,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -468,6 +468,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -805,6 +812,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -236,6 +236,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -430,6 +437,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -374,6 +374,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -388,6 +395,13 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "featured_attachments": {
+          "description": "An ordered list of attachments to feature on the page",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
@@ -696,6 +710,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -501,6 +501,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -515,6 +522,13 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "featured_attachments": {
+          "description": "An ordered list of attachments to feature on the page",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
@@ -790,6 +804,25 @@
         "zh-tw"
       ]
     },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",
       "type": "object",
@@ -840,6 +873,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -296,6 +296,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -310,6 +317,13 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "featured_attachments": {
+          "description": "An ordered list of attachments to feature on the page",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
@@ -446,6 +460,25 @@
         "zh-tw"
       ]
     },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",
       "type": "object",
@@ -492,6 +525,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -305,6 +305,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -580,6 +587,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -411,6 +411,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -703,6 +710,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -210,6 +210,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -359,6 +366,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -296,6 +296,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -519,6 +526,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -398,6 +398,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -638,6 +645,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -175,6 +175,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -269,6 +276,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -306,6 +306,13 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
@@ -555,6 +562,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -422,6 +422,13 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
@@ -688,6 +695,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -193,6 +193,13 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "change_note": {
           "$ref": "#/definitions/change_note"
         },
@@ -313,6 +320,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -315,6 +315,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -625,6 +632,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -431,6 +431,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -758,6 +765,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -201,6 +201,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "attachments": {
+          "description": "An ordered list of asset links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/publication_attachment_asset"
+          }
+        },
         "body": {
           "$ref": "#/definitions/body"
         },
@@ -385,6 +392,186 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "publication_attachment_asset": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "content_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accessible": {
+              "type": "boolean"
+            },
+            "alternative_format_contact_email": {
+              "type": "string"
+            },
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "content_type": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "integer"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "number_of_pages": {
+              "type": "integer"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "preview_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "html"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "attachment_type",
+            "id",
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attachment_type": {
+              "type": "string",
+              "enum": [
+                "external"
+              ]
+            },
+            "command_paper_number": {
+              "type": "string"
+            },
+            "hoc_paper_number": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "locale": {
+              "$ref": "#/definitions/locale"
+            },
+            "parliamentary_session": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unique_reference": {
+              "type": "string"
+            },
+            "unnumbered_command_paper": {
+              "type": "boolean"
+            },
+            "unnumbered_hoc_paper": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/formats/consultation.jsonnet
+++ b/formats/consultation.jsonnet
@@ -15,6 +15,13 @@
         "political",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/consultation.jsonnet
+++ b/formats/consultation.jsonnet
@@ -22,6 +22,13 @@
             "$ref": "#/definitions/publication_attachment_asset",
           },
         },
+        featured_attachments: {
+          description: "An ordered list of attachments to feature on the page",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/multiple_content_types",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/corporate_information_page.jsonnet
+++ b/formats/corporate_information_page.jsonnet
@@ -31,6 +31,13 @@
         "organisation",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -13,6 +13,13 @@
         "political",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/news_article.jsonnet
+++ b/formats/news_article.jsonnet
@@ -13,6 +13,13 @@
         "body",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -39,6 +39,13 @@
             "$ref": "#/definitions/publication_attachment_asset",
           },
         },
+        featured_attachments: {
+          description: "An ordered list of attachments to feature on the page",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/multiple_content_types",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -32,6 +32,13 @@
         "political",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/statistical_data_set.jsonnet
+++ b/formats/statistical_data_set.jsonnet
@@ -10,6 +10,13 @@
         "political",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },

--- a/formats/working_group.jsonnet
+++ b/formats/working_group.jsonnet
@@ -5,6 +5,13 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         email: {
           type: "string",
         },

--- a/formats/world_location.jsonnet
+++ b/formats/world_location.jsonnet
@@ -10,6 +10,13 @@
        analytics_identifier: {
           "$ref": "#/definitions/analytics_identifier",
         },
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         change_note: {
           "$ref": "#/definitions/change_note",
         },

--- a/formats/world_location_news_article.jsonnet
+++ b/formats/world_location_news_article.jsonnet
@@ -10,6 +10,13 @@
         "political",
       ],
       properties: {
+        attachments: {
+          description: "An ordered list of asset links",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/publication_attachment_asset",
+          },
+        },
         body: {
           "$ref": "#/definitions/body",
         },


### PR DESCRIPTION
This does part (i) of steps 5 and 6 of [the RFC implementation](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-116-store-attachment-data-in-content-items.md).

See commit messages for more details.