### PR TITLE
Remove appear_in_find_eu_exit_guidance_business_finder

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -519,9 +519,6 @@
             "type": "string"
           }
         },
-        "appear_in_find_eu_exit_guidance_business_finder": {
-          "type": "string"
-        },
         "content_purpose_subgroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -635,9 +635,6 @@
             "type": "string"
           }
         },
-        "appear_in_find_eu_exit_guidance_business_finder": {
-          "type": "string"
-        },
         "content_purpose_subgroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -385,9 +385,6 @@
             "type": "string"
           }
         },
-        "appear_in_find_eu_exit_guidance_business_finder": {
-          "type": "string"
-        },
         "content_purpose_subgroup": {
           "type": "array",
           "items": {

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -48,9 +48,6 @@
           type: "string",
         },
       },
-      appear_in_find_eu_exit_guidance_business_finder: {
-        type: "string",
-      },
       facet_groups: {
           type: "array",
           items: {


### PR DESCRIPTION
Trello: https://trello.com/c/qBM5QLID/482-business-finder-tech-debt

`appear_in_find_eu_exit_guidance_business_finder` is old technical debt surfaced [as part of removing the business finder](https://github.com/alphagov/search-api/pull/1967).

>It looks like the appear_in_find_eu_exit_guidance_business_finder checkbox approach was >replaced the facet_groups approach:
>
>    alphagov/finder-frontend@6f484a6
>    https://github.com/alphagov/search-api/pull/1535/files
>
>The finder content schema needs to have appear_in_find_eu_exit_guidance_business_finder removed too: https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/finder.jsonnet#L51.

Removes `appear_in_find_eu_exit_guidance_business_finder` from:
- Finder Frontend schema json
- Finder Notification schema json
- Finder Publisher v2 schema json
- Finder shared defintions jsonnet
