### PR TITLE
Get featured attachments working properly

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -355,7 +355,17 @@
           "$ref": "#/definitions/emphasised_organisations"
         },
         "featured_attachments": {
-          "type": "string"
+          "description": "An ordered list of attachments to feature below the document",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "final_outcome_attachments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "final_outcome_detail": {
           "type": "string"
@@ -388,6 +398,12 @@
         },
         "political": {
           "$ref": "#/definitions/political"
+        },
+        "public_feedback_attachments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "public_feedback_detail": {
           "type": "string"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -476,7 +476,17 @@
           "$ref": "#/definitions/emphasised_organisations"
         },
         "featured_attachments": {
-          "$ref": "#/definitions/multiple_content_types"
+          "description": "An ordered list of attachments to feature below the document",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
+        },
+        "final_outcome_attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "final_outcome_detail": {
           "type": "string"
@@ -509,6 +519,12 @@
         },
         "political": {
           "$ref": "#/definitions/political"
+        },
+        "public_feedback_attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "public_feedback_detail": {
           "type": "string"

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -277,7 +277,17 @@
           "$ref": "#/definitions/emphasised_organisations"
         },
         "featured_attachments": {
-          "$ref": "#/definitions/multiple_content_types"
+          "description": "An ordered list of attachments to feature below the document",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
+        },
+        "final_outcome_attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "final_outcome_detail": {
           "type": "string"
@@ -310,6 +320,12 @@
         },
         "political": {
           "$ref": "#/definitions/political"
+        },
+        "public_feedback_attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "public_feedback_detail": {
           "type": "string"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -397,7 +397,11 @@
           "$ref": "#/definitions/emphasised_organisations"
         },
         "featured_attachments": {
-          "type": "string"
+          "description": "An ordered list of attachments to feature below the document",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -524,7 +524,11 @@
           "$ref": "#/definitions/emphasised_organisations"
         },
         "featured_attachments": {
-          "$ref": "#/definitions/multiple_content_types"
+          "description": "An ordered list of attachments to feature below the document",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -319,7 +319,11 @@
           "$ref": "#/definitions/emphasised_organisations"
         },
         "featured_attachments": {
-          "$ref": "#/definitions/multiple_content_types"
+          "description": "An ordered list of attachments to feature below the document",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/multiple_content_types"
+          }
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"

--- a/formats/consultation.jsonnet
+++ b/formats/consultation.jsonnet
@@ -23,7 +23,11 @@
           },
         },
         featured_attachments: {
-          "$ref": "#/definitions/multiple_content_types",
+          description: "An ordered list of attachments to feature below the document",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/multiple_content_types",
+          },
         },
         body: {
           "$ref": "#/definitions/body",

--- a/formats/consultation.jsonnet
+++ b/formats/consultation.jsonnet
@@ -95,6 +95,12 @@
         public_feedback_documents: {
           "$ref": "#/definitions/attachments_with_thumbnails",
         },
+        public_feedback_attachments: {
+          type: "array",
+          items: {
+            "$ref": "#/definitions/multiple_content_types",
+          },
+        },
         final_outcome_publication_date: {
           type: "string",
           format: "date-time",
@@ -104,6 +110,12 @@
         },
         final_outcome_documents: {
           "$ref": "#/definitions/attachments_with_thumbnails",
+        },
+        final_outcome_attachments: {
+          type: "array",
+          items: {
+            "$ref": "#/definitions/multiple_content_types",
+          },
         },
         tags: {
           "$ref": "#/definitions/tags",

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -40,7 +40,11 @@
           },
         },
         featured_attachments: {
-          "$ref": "#/definitions/multiple_content_types",
+          description: "An ordered list of attachments to feature below the document",
+          type: "array",
+          items: {
+            "$ref": "#/definitions/multiple_content_types",
+          },
         },
         body: {
           "$ref": "#/definitions/body",


### PR DESCRIPTION
Two problems with the way it was done before:

1. The `multiple_content_types` schema means that all of the things are *different representations of the same content*, and so content-store only returns the *first* `text/html` found.  And not the full list as I'd assumed.

2. Consultations have a few more types of documents which need to be attachments-ised.

Immediate solution to (1) is to wrap the featured attachments in an array, so we have an array of arrays.  Long term solution to (1) (which may not be feasible) would be to make the semantics really clear, by changing it to a hash, where keys are content types and values are representations.

[Trello card](https://trello.com/c/ZTfLGWYT/1387-get-whitehall-sending-attachments-featuredattachments-data-to-publishing-api)