### PR TITLE
Remove required government attributes

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -326,7 +326,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -447,7 +447,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -248,7 +248,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -331,7 +331,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -447,7 +447,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -217,7 +217,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -332,7 +332,6 @@
       "type": "object",
       "required": [
         "collection_groups",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -450,7 +450,6 @@
       "type": "object",
       "required": [
         "collection_groups",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -248,7 +248,6 @@
       "type": "object",
       "required": [
         "collection_groups",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -369,7 +369,6 @@
       "required": [
         "body",
         "documents",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -496,7 +496,6 @@
       "required": [
         "body",
         "documents",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -291,7 +291,6 @@
       "required": [
         "body",
         "documents",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -330,7 +330,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -463,7 +463,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -199,7 +199,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -300,7 +300,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -406,7 +406,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -205,7 +205,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/formats/consultation.jsonnet
+++ b/formats/consultation.jsonnet
@@ -11,7 +11,6 @@
       additionalProperties: false,
       required: [
         "body",
-        "government",
         "political",
       ],
       properties: {

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -9,7 +9,6 @@
       additionalProperties: false,
       required: [
         "body",
-        "government",
         "political",
       ],
       properties: {

--- a/formats/document_collection.jsonnet
+++ b/formats/document_collection.jsonnet
@@ -6,7 +6,6 @@
       additionalProperties: false,
       required: [
         "collection_groups",
-        "government",
         "political",
       ],
       properties: {

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -28,7 +28,6 @@
       required: [
         "body",
         "documents",
-        "government",
         "political",
       ],
       properties: {

--- a/formats/speech.jsonnet
+++ b/formats/speech.jsonnet
@@ -11,7 +11,6 @@
       additionalProperties: false,
       required: [
         "body",
-        "government",
         "political",
         "delivered_on",
       ],

--- a/formats/statistical_data_set.jsonnet
+++ b/formats/statistical_data_set.jsonnet
@@ -6,7 +6,6 @@
       additionalProperties: false,
       required: [
         "body",
-        "government",
         "political",
       ],
       properties: {


### PR DESCRIPTION
Usage of government in a details hash is deprecated following the change
of #943, because
of this it shouldn't be required for any document types. This removes
all the required options.