### PR TITLE
Remove government from required world location news article list

### DIFF
--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -310,7 +310,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -426,7 +426,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -196,7 +196,6 @@
       "type": "object",
       "required": [
         "body",
-        "government",
         "political"
       ],
       "additionalProperties": false,

--- a/formats/world_location_news_article.jsonnet
+++ b/formats/world_location_news_article.jsonnet
@@ -6,7 +6,6 @@
       additionalProperties: false,
       required: [
         "body",
-        "government",
         "political",
       ],
       properties: {


### PR DESCRIPTION
The links to governments are now used for associating content with
governments.