### PR TITLE
Set Whitehall document attachments to be file_attachment_asset

### DIFF
--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -337,7 +337,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -367,6 +367,59 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
         "title": {
           "type": "string"
         },
@@ -643,186 +696,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -447,7 +447,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -477,6 +477,59 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
         "title": {
           "type": "string"
         },
@@ -770,186 +823,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -251,7 +251,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -281,6 +281,59 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
         "title": {
           "type": "string"
         },
@@ -431,186 +484,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -348,7 +348,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -395,6 +395,59 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/guid"
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "first_public_at": {
@@ -722,186 +775,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -464,7 +464,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -511,6 +511,59 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/guid"
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "first_public_at": {
@@ -855,186 +908,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -234,7 +234,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -281,6 +281,59 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/guid"
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "first_public_at": {
@@ -482,186 +535,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -338,7 +338,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -372,6 +372,59 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/guid"
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "first_public_at": {
@@ -661,186 +714,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -472,7 +472,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -506,6 +506,59 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/guid"
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "first_public_at": {
@@ -812,186 +865,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -240,7 +240,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -274,6 +274,59 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/guid"
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "first_public_at": {
@@ -437,186 +490,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -300,7 +300,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -311,6 +311,59 @@
         },
         "email": {
           "type": "string"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -526,186 +579,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -402,7 +402,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -413,6 +413,59 @@
         },
         "email": {
           "type": "string"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -645,186 +698,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -179,7 +179,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -187,6 +187,59 @@
         },
         "email": {
           "type": "string"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -276,186 +329,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -318,7 +318,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -341,6 +341,59 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -631,186 +684,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -434,7 +434,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -457,6 +457,59 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -764,186 +817,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -204,7 +204,7 @@
           "description": "An ordered list of asset links",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/publication_attachment_asset"
+            "$ref": "#/definitions/file_attachment_asset"
           }
         },
         "body": {
@@ -227,6 +227,59 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "file_attachment_asset": {
+      "type": "object",
+      "required": [
+        "attachment_type",
+        "content_type",
+        "id",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "accessible": {
+          "type": "boolean"
+        },
+        "alternative_format_contact_email": {
+          "type": "string"
+        },
+        "attachment_type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "file_size": {
+          "type": "integer"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "$ref": "#/definitions/locale"
+        },
+        "number_of_pages": {
+          "type": "integer"
+        },
+        "preview_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -391,186 +444,6 @@
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "publication_attachment_asset": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "content_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "accessible": {
-              "type": "boolean"
-            },
-            "alternative_format_contact_email": {
-              "type": "string"
-            },
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "content_type": {
-              "type": "string"
-            },
-            "file_size": {
-              "type": "integer"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "number_of_pages": {
-              "type": "integer"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "preview_url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "html"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attachment_type",
-            "id",
-            "url"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "attachment_type": {
-              "type": "string",
-              "enum": [
-                "external"
-              ]
-            },
-            "command_paper_number": {
-              "type": "string"
-            },
-            "hoc_paper_number": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "isbn": {
-              "type": "string"
-            },
-            "locale": {
-              "$ref": "#/definitions/locale"
-            },
-            "parliamentary_session": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "unique_reference": {
-              "type": "string"
-            },
-            "unnumbered_command_paper": {
-              "type": "boolean"
-            },
-            "unnumbered_hoc_paper": {
-              "type": "boolean"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        }
-      ]
     },
     "publishing_app_name": {
       "description": "The application that published this item.",

--- a/formats/corporate_information_page.jsonnet
+++ b/formats/corporate_information_page.jsonnet
@@ -35,7 +35,7 @@
           description: "An ordered list of asset links",
           type: "array",
           items: {
-            "$ref": "#/definitions/publication_attachment_asset",
+            "$ref": "#/definitions/file_attachment_asset",
           },
         },
         body: {

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -16,7 +16,7 @@
           description: "An ordered list of asset links",
           type: "array",
           items: {
-            "$ref": "#/definitions/publication_attachment_asset",
+            "$ref": "#/definitions/file_attachment_asset",
           },
         },
         body: {

--- a/formats/news_article.jsonnet
+++ b/formats/news_article.jsonnet
@@ -17,7 +17,7 @@
           description: "An ordered list of asset links",
           type: "array",
           items: {
-            "$ref": "#/definitions/publication_attachment_asset",
+            "$ref": "#/definitions/file_attachment_asset",
           },
         },
         body: {

--- a/formats/working_group.jsonnet
+++ b/formats/working_group.jsonnet
@@ -9,7 +9,7 @@
           description: "An ordered list of asset links",
           type: "array",
           items: {
-            "$ref": "#/definitions/publication_attachment_asset",
+            "$ref": "#/definitions/file_attachment_asset",
           },
         },
         email: {

--- a/formats/world_location_news_article.jsonnet
+++ b/formats/world_location_news_article.jsonnet
@@ -13,7 +13,7 @@
           description: "An ordered list of asset links",
           type: "array",
           items: {
-            "$ref": "#/definitions/publication_attachment_asset",
+            "$ref": "#/definitions/file_attachment_asset",
           },
         },
         body: {


### PR DESCRIPTION
Prior to this being merged https://github.com/alphagov/whitehall/pull/5448 will have to be merged and deployed to production.

Previously all of these documents were set to use the publication attachment schemas, however none of these documents make use of publication specific fields or types. Thus this reduces the options that can apply at a schema level for them.

@barrucadu I've opened this up and marked it as a draft prior to you get your input on this. I'm wondering if there was a reason these document types were set as publication attachment assets in the first place that I've missed and/or if there are consequences to this change? might it break any Whitehall document types.