### PR TITLE
Coronavirus document type

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -59,6 +59,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -85,6 +85,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -69,6 +69,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -59,6 +59,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -85,6 +85,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -69,6 +69,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -59,6 +59,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -85,6 +85,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -69,6 +69,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -62,6 +62,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -88,6 +88,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -69,6 +69,7 @@
         "consultation",
         "consultation_outcome",
         "contact",
+        "coronavirus_landing_page",
         "corporate_report",
         "correspondence",
         "countryside_stewardship_grant",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -23,6 +23,7 @@
 - consultation
 - consultation_outcome
 - contact
+- coronavirus_landing_page
 - corporate_report
 - correspondence
 - countryside_stewardship_grant


### PR DESCRIPTION
Adds a placeholder coronavirus_landing_page document type so that we can spike a possible publishing workflow for the coronavirus landing page. 

https://trello.com/c/0uZVAYYt/35-look-at-options-for-publishers-to-update-page