### PR TITLE
Add new examples for direct attachment rendering

### DIFF
--- a/examples/consultation/frontend/consultation_outcome_with_featured_attachments.json
+++ b/examples/consultation/frontend/consultation_outcome_with_featured_attachments.json
@@ -1,0 +1,622 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+  "content_id": "67e7930a-9e13-4a70-a5be-fc18aa8fa6f5",
+  "document_type": "consultation_outcome",
+  "first_published_at": "2016-04-20T10:44:19.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2016-09-07T11:00:28.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": null,
+  "rendering_app": "government-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "consultation",
+  "title": "Setting the grade standards of new GCSEs in England: 2017 & 2018",
+  "updated_at": "2020-03-25T13:12:13.989Z",
+  "withdrawn_notice": {
+  },
+  "publishing_request_id": "11712-1583762694.843-10.13.6.141-539",
+  "links": {
+    "document_collections": [
+      {
+        "content_id": "d53fa271-2985-4c15-ad22-5fdb18c78f48",
+        "title": "GCSE, AS and A level reforms",
+        "locale": "en",
+        "api_path": "/api/content/government/collections/gcse-as-and-a-level-reforms",
+        "base_path": "/government/collections/gcse-as-and-a-level-reforms",
+        "document_type": "document_collection",
+        "public_updated_at": "2018-08-28T10:28:01Z",
+        "schema_name": "document_collection",
+        "withdrawn": false,
+        "links": {
+          "documents": [
+            {
+              "content_id": "67e7930a-9e13-4a70-a5be-fc18aa8fa6f5",
+              "title": "Setting the grade standards of new GCSEs in England: 2017 & 2018",
+              "locale": "en",
+              "api_path": "/api/content/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+              "base_path": "/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+              "document_type": "consultation_outcome",
+              "public_updated_at": "2016-09-07T11:00:28Z",
+              "schema_name": "consultation",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+              "web_url": "https://www.gov.uk/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/collections/gcse-as-and-a-level-reforms",
+        "web_url": "https://www.gov.uk/government/collections/gcse-as-and-a-level-reforms"
+      }
+    ],
+    "government": [
+      {
+        "content_id": "d4fbc1b9-d47d-4386-af04-ac909f868f92",
+        "title": "2015 Conservative government",
+        "locale": "en",
+        "api_path": "/api/content/government/2015-conservative-government",
+        "base_path": "/government/2015-conservative-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2015-05-08T00:00:00+00:00",
+          "ended_on": null,
+          "current": true
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/2015-conservative-government",
+        "web_url": "https://www.gov.uk/government/2015-conservative-government"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "83f6e93f-bb2c-46ab-9b02-394f972b7030",
+        "title": "Ofqual",
+        "locale": "en",
+        "analytics_identifier": "D109",
+        "api_path": "/api/content/government/organisations/ofqual",
+        "base_path": "/government/organisations/ofqual",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Ofqual",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/109/ofqual_gov_uk_logo.png",
+              "alt_text": "Ofqual"
+            }
+          },
+          "brand": "department-for-education",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/400/s300_Default_News_Image.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/400/s960_Default_News_Image.jpg"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/ofqual",
+        "web_url": "https://www.gov.uk/government/organisations/ofqual"
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "83f6e93f-bb2c-46ab-9b02-394f972b7030",
+        "title": "Ofqual",
+        "locale": "en",
+        "analytics_identifier": "D109",
+        "api_path": "/api/content/government/organisations/ofqual",
+        "base_path": "/government/organisations/ofqual",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Ofqual",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/109/ofqual_gov_uk_logo.png",
+              "alt_text": "Ofqual"
+            }
+          },
+          "brand": "department-for-education",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/400/s300_Default_News_Image.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/400/s960_Default_News_Image.jpg"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/ofqual",
+        "web_url": "https://www.gov.uk/government/organisations/ofqual"
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "83f6e93f-bb2c-46ab-9b02-394f972b7030",
+        "title": "Ofqual",
+        "locale": "en",
+        "analytics_identifier": "D109",
+        "api_path": "/api/content/government/organisations/ofqual",
+        "base_path": "/government/organisations/ofqual",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Ofqual",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/109/ofqual_gov_uk_logo.png",
+              "alt_text": "Ofqual"
+            }
+          },
+          "brand": "department-for-education",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/400/s300_Default_News_Image.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/400/s960_Default_News_Image.jpg"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/ofqual",
+        "web_url": "https://www.gov.uk/government/organisations/ofqual"
+      }
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "20130d1b-bea9-4ce6-9331-d896c1e42d55",
+        "title": "GCSE (9 to 1) subject-level guidance for ancient languages",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-ancient-languages",
+        "base_path": "/government/publications/gcse-9-to-1-subject-level-guidance-for-ancient-languages",
+        "document_type": "statutory_guidance",
+        "public_updated_at": "2017-03-30T11:00:01Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-ancient-languages",
+        "web_url": "https://www.gov.uk/government/publications/gcse-9-to-1-subject-level-guidance-for-ancient-languages"
+      },
+      {
+        "content_id": "d80635d3-6be9-4ded-a864-0ec17f9b38b3",
+        "title": "GCSE (9 to 1) subject-level guidance for drama",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-drama",
+        "base_path": "/government/publications/gcse-9-to-1-subject-level-guidance-for-drama",
+        "document_type": "statutory_guidance",
+        "public_updated_at": "2015-07-24T15:22:00Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-drama",
+        "web_url": "https://www.gov.uk/government/publications/gcse-9-to-1-subject-level-guidance-for-drama"
+      },
+      {
+        "content_id": "4d6cf245-6957-4e76-b82b-d4b741a055d7",
+        "title": "GCSE (9 to 1) subject-level guidance for dance",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-dance",
+        "base_path": "/government/publications/gcse-9-to-1-subject-level-guidance-for-dance",
+        "document_type": "statutory_guidance",
+        "public_updated_at": "2015-03-16T15:21:00Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-dance",
+        "web_url": "https://www.gov.uk/government/publications/gcse-9-to-1-subject-level-guidance-for-dance"
+      },
+      {
+        "content_id": "e97897e4-4e17-4d4e-a9c6-3040e451f3c1",
+        "title": "GCSE (9 to 1) subject-level conditions and requirements for ancient languages",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/gcse-9-to-1-subject-level-conditions-and-requirements-for-ancient-languages",
+        "base_path": "/government/publications/gcse-9-to-1-subject-level-conditions-and-requirements-for-ancient-languages",
+        "document_type": "regulation",
+        "public_updated_at": "2018-03-21T10:51:31Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/publications/gcse-9-to-1-subject-level-conditions-and-requirements-for-ancient-languages",
+        "web_url": "https://www.gov.uk/government/publications/gcse-9-to-1-subject-level-conditions-and-requirements-for-ancient-languages"
+      },
+      {
+        "content_id": "d0f5414f-a2ab-4897-9f5f-1bd0521bde24",
+        "title": "GCSE (9 to 1) subject-level guidance for music",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-music",
+        "base_path": "/government/publications/gcse-9-to-1-subject-level-guidance-for-music",
+        "document_type": "statutory_guidance",
+        "public_updated_at": "2015-03-16T15:19:00Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/publications/gcse-9-to-1-subject-level-guidance-for-music",
+        "web_url": "https://www.gov.uk/government/publications/gcse-9-to-1-subject-level-guidance-for-music"
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "af89d06d-db1c-4a37-a8df-63d1e308c183",
+        "title": "Key stage 3 and 4 exam marking, qualifications and results",
+        "locale": "en",
+        "api_path": "/api/content/education/key-stage-3-and-4-exam-marking-qualifications-and-results",
+        "base_path": "/education/key-stage-3-and-4-exam-marking-qualifications-and-results",
+        "document_type": "taxon",
+        "public_updated_at": "2017-02-24T17:52:46Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Regulated qualifications, awarding bodies, assessing, marking, participation and performance, appeals, National Reference Test.",
+        "details": {
+          "internal_name": "Key stage 3 and 4 exam marking, qualifications and results",
+          "notes_for_editors": ""
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "a28530a2-b0a3-46f9-89b9-3d98fc18e39d",
+              "title": "Secondary curriculum, key stage 3 and key stage 4 (GCSEs)",
+              "locale": "en",
+              "api_path": "/api/content/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses",
+              "base_path": "/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-29T12:55:43Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Programmes of study, English Baccalaureate (EBacc), qualifications, core and foundation subjects, changes to GCSEs.",
+              "details": {
+                "internal_name": "Secondary curriculum, key stage 3 and key stage 4 (GCSEs)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
+                    "title": "School curriculum",
+                    "locale": "en",
+                    "api_path": "/api/content/education/school-curriculum",
+                    "base_path": "/education/school-curriculum",
+                    "document_type": "taxon",
+                    "public_updated_at": "2017-06-29T13:00:11Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "The national curriculum, early years, key stages 1 to 5, GCSEs and AS and A levels, tests, exams and assessments.",
+                    "details": {
+                      "internal_name": "School curriculum",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+                          "title": "Education, training and skills",
+                          "locale": "en",
+                          "api_path": "/api/content/education",
+                          "base_path": "/education",
+                          "document_type": "taxon",
+                          "public_updated_at": "2018-06-07T15:19:07Z",
+                          "schema_name": "taxon",
+                          "withdrawn": false,
+                          "description": "Schools and academies, further and higher education, apprenticeships and other skills training, student funding, early years.",
+                          "details": {
+                            "internal_name": "Education, training and skills",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "title": "GOV.UK homepage",
+                                "locale": "en",
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "document_type": "homepage",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "withdrawn": false,
+                                "links": {
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/education",
+                          "web_url": "https://www.gov.uk/education"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/education/school-curriculum",
+                    "web_url": "https://www.gov.uk/education/school-curriculum"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses",
+              "web_url": "https://www.gov.uk/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/education/key-stage-3-and-4-exam-marking-qualifications-and-results",
+        "web_url": "https://www.gov.uk/education/key-stage-3-and-4-exam-marking-qualifications-and-results"
+      },
+      {
+        "content_id": "cf1a5c02-ed35-48f3-9e17-c702cc23ea92",
+        "title": "GCSE changes and reforms",
+        "locale": "en",
+        "api_path": "/api/content/education/gcse-changes-and-reforms",
+        "base_path": "/education/gcse-changes-and-reforms",
+        "document_type": "taxon",
+        "public_updated_at": "2017-02-24T17:53:02Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Consultations, research and guidance about changes to subjects, regulations, assessment, grading and appeals.",
+        "details": {
+          "internal_name": "GCSE changes and reforms",
+          "notes_for_editors": ""
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "a28530a2-b0a3-46f9-89b9-3d98fc18e39d",
+              "title": "Secondary curriculum, key stage 3 and key stage 4 (GCSEs)",
+              "locale": "en",
+              "api_path": "/api/content/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses",
+              "base_path": "/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-29T12:55:43Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Programmes of study, English Baccalaureate (EBacc), qualifications, core and foundation subjects, changes to GCSEs.",
+              "details": {
+                "internal_name": "Secondary curriculum, key stage 3 and key stage 4 (GCSEs)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
+                    "title": "School curriculum",
+                    "locale": "en",
+                    "api_path": "/api/content/education/school-curriculum",
+                    "base_path": "/education/school-curriculum",
+                    "document_type": "taxon",
+                    "public_updated_at": "2017-06-29T13:00:11Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "The national curriculum, early years, key stages 1 to 5, GCSEs and AS and A levels, tests, exams and assessments.",
+                    "details": {
+                      "internal_name": "School curriculum",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+                          "title": "Education, training and skills",
+                          "locale": "en",
+                          "api_path": "/api/content/education",
+                          "base_path": "/education",
+                          "document_type": "taxon",
+                          "public_updated_at": "2018-06-07T15:19:07Z",
+                          "schema_name": "taxon",
+                          "withdrawn": false,
+                          "description": "Schools and academies, further and higher education, apprenticeships and other skills training, student funding, early years.",
+                          "details": {
+                            "internal_name": "Education, training and skills",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "title": "GOV.UK homepage",
+                                "locale": "en",
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "document_type": "homepage",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "withdrawn": false,
+                                "links": {
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/education",
+                          "web_url": "https://www.gov.uk/education"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/education/school-curriculum",
+                    "web_url": "https://www.gov.uk/education/school-curriculum"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses",
+              "web_url": "https://www.gov.uk/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/education/gcse-changes-and-reforms",
+        "web_url": "https://www.gov.uk/education/gcse-changes-and-reforms"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Setting the grade standards of new GCSEs in England: 2017 & 2018",
+        "public_updated_at": "2016-09-07T11:00:28Z",
+        "document_type": "consultation_outcome",
+        "schema_name": "consultation",
+        "base_path": "/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+        "api_path": "/api/content/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+        "withdrawn": false,
+        "content_id": "67e7930a-9e13-4a70-a5be-fc18aa8fa6f5",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+        "web_url": "https://www.gov.uk/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "Proposals on grade standards for GCSEs being awarded from 2018, and grades 8 and 9 in maths, English language and English literature from 2017.",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>We are seeking views on our proposals for setting grade standards for new GCSEs. This consultation follows on from our earlier consultation on <a rel=\"external\" href=\"http://webarchive.nationalarchives.gov.uk/20141110161323/http:/comment.ofqual.gov.uk/setting-the-grade-standards-of-new-gcses-april-2014/\" class=\"govuk-link\">‘Setting the grade standards of new GCSEs in England’</a>.</p>\n\n<p>In September 2014 we announced our decisions about the awarding of new GCSEs in English language, English literature and mathematics which will be first awarded in summer 2017.</p>\n\n<p>We are now consulting on the approach to be taken in all other subjects. We are also consulting on a change to our previous decisions for English language, English literature and mathematics, about how grades 8 and 9 are set.</p>\n\n<p>Our proposals are designed to protect students taking the new qualifications, particularly in the first year when teachers will be less familiar with the new content and how it is assessed. We want to minimise unexpected or unfair outcomes for students in the transition to the new GCSEs.</p>\n</div>",
+    "closing_date": "2016-06-17T23:45:00.000+01:00",
+    "emphasised_organisations": [
+      "83f6e93f-bb2c-46ab-9b02-394f972b7030"
+    ],
+    "opening_date": "2016-04-22T12:00:00.000+01:00",
+    "change_history": [
+      {
+        "public_timestamp": "2016-09-07T12:00:28.000+01:00",
+        "note": "Published the decisions and analysis of responses."
+      },
+      {
+        "public_timestamp": "2016-04-22T12:00:00.000+01:00",
+        "note": "First published."
+      }
+    ],
+    "featured_attachments": [
+      "Setting_grade_standards_part_2.pdf"
+    ],
+    "final_outcome_detail": "<div class=\"govspeak\"><p>We have decided that:</p>\n\n<ol>\n  <li>The first award of all new GCSEs will be based primarily on statistical predictions with examiner judgement playing a secondary role. A modified approach, based on a wider range of information, will be used where needed because of the size and nature of the candidature.</li>\n  <li>The grade standard established in the first award will be carried forward in the second and subsequent years.</li>\n  <li>The same approach will be used for the first awards of grades 1 to 7 in all new GCSEs as has already been confirmed for new GCSEs in English language, English literature and maths. This approach uses key reference points between current (alphabetical) and new (numerical) grades to set grade standards in the new qualifications.</li>\n  <li>The ‘tailored’ approach’ will be used to set standards for grades 8 and 9 in all new GCSEs in the first year they are awarded, including English language, English literature and maths.</li>\n  <li>The standard established in the first award for grades 8 and 9 will be carried forward in the second and subsequent years.</li>\n</ol>\n</div>",
+    "final_outcome_attachments": [
+      "Decisions_-_setting_GCSE_grade_standards_-_part_2.pdf",
+      "Grading-consulation-Equalities-Impact-Assessment.pdf"
+    ],
+    "national_applicability": {
+      "england": {
+        "label": "England",
+        "applicable": true
+      },
+      "northern_ireland": {
+        "label": "Northern Ireland",
+        "applicable": false,
+        "alternative_url": ""
+      },
+      "scotland": {
+        "label": "Scotland",
+        "applicable": false,
+        "alternative_url": ""
+      },
+      "wales": {
+        "label": "Wales",
+        "applicable": false,
+        "alternative_url": ""
+      }
+    },
+    "public_feedback_detail": "<div class=\"govspeak\"><p>The majority of respondents agreed or strongly agreed with our proposals, which were:</p>\n\n<ol>\n  <li>That the first award of new GCSEs will be based primarily on statistical predictions, with examiner judgement playing a secondary role. A modified approach based on a wider range of information and with less reliance on statistics will be used where appropriate.</li>\n  <li>To the award of new GCSEs in the second and subsequent years: to carry forward the grade standard established in the first award.</li>\n  <li>To adopt the same approach to the first award of grades 1 to 7 in all new GCSEs as that which we have confirmed will be adopted for new GCSEs in English language, English literature and maths.</li>\n  <li>To adopt the ‘tailored approach’ to awarding grade 9 in subjects to be awarded from summer 2018.</li>\n  <li>To also adopt the ‘tailored approach’ to awarding grade 9 in English language, English literature and maths from summer 2017.</li>\n</ol>\n\n<p>Just under half of the respondents (49%) agreed or strongly agreed with our proposal to base the award of grade 9 in the second and subsequent years on the standard set in the first award. 30% disagreed with this proposal. The remaining 21% neither agreed nor disagreed.</p>\n</div>",
+    "public_feedback_attachments": [
+      "Grading-consultation-analysis-of-responses.pdf"
+    ],
+    "public_feedback_publication_date": "2016-09-07T00:00:00+00:00",
+    "first_public_at": "2016-04-22T12:00:00.000+01:00",
+    "political": false,
+    "government": {
+      "title": "2015 Conservative government",
+      "slug": "2015-conservative-government",
+      "current": true
+    },
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "attachments": [
+      {
+        "attachment_type": "file",
+        "id": "Setting_grade_standards_part_2.pdf",
+        "title": "Setting the grade standards of new GCSEs in England – part 2",
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/529862/Setting_grade_standards_part_2.pdf",
+        "command_paper_number": "",
+        "hoc_paper_number": "",
+        "isbn": "",
+        "unique_reference": "Ofqual/16/5939",
+        "unnumbered_command_paper": false,
+        "unnumbered_hoc_paper": false,
+        "accessible": false,
+        "alternative_format_contact_email": "publications@ofqual.gov.uk",
+        "content_type": "application/pdf",
+        "file_size": 803783,
+        "filename": "Setting_grade_standards_part_2.pdf",
+        "number_of_pages": 33
+      },
+      {
+        "attachment_type": "file",
+        "id": "Decisions_-_setting_GCSE_grade_standards_-_part_2.pdf",
+        "title": "Decisions on setting the grade standards of new GCSEs in England - part 2",
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/551571/Decisions_-_setting_GCSE_grade_standards_-_part_2.pdf",
+        "command_paper_number": "",
+        "hoc_paper_number": "",
+        "isbn": "",
+        "unique_reference": "Ofqual/16/6102",
+        "unnumbered_command_paper": false,
+        "unnumbered_hoc_paper": false,
+        "accessible": false,
+        "alternative_format_contact_email": "publications@ofqual.gov.uk",
+        "content_type": "application/pdf",
+        "file_size": 365608,
+        "filename": "Decisions_-_setting_GCSE_grade_standards_-_part_2.pdf",
+        "number_of_pages": 10
+      },
+      {
+        "attachment_type": "file",
+        "id": "Grading-consulation-Equalities-Impact-Assessment.pdf",
+        "title": "Equalities impact assessment: setting the grade standards of new GCSEs in England – part 2",
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/551115/Grading-consulation-Equalities-Impact-Assessment.pdf",
+        "command_paper_number": "",
+        "hoc_paper_number": "",
+        "isbn": "",
+        "unique_reference": "Ofqual/16/6104",
+        "unnumbered_command_paper": false,
+        "unnumbered_hoc_paper": false,
+        "accessible": false,
+        "alternative_format_contact_email": "publications@ofqual.gov.uk",
+        "content_type": "application/pdf",
+        "file_size": 64614,
+        "filename": "Grading-consulation-Equalities-Impact-Assessment.pdf",
+        "number_of_pages": 5
+      },
+      {
+        "attachment_type": "file",
+        "id": "Grading-consultation-analysis-of-responses.pdf",
+        "title": "Analysis of responses to our consultation on setting the grade standards of new GCSEs in England – part 2",
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/551112/Grading-consultation-analysis-of-responses.pdf",
+        "unnumbered_command_paper": false,
+        "unnumbered_hoc_paper": false,
+        "accessible": false,
+        "alternative_format_contact_email": "publications@ofqual.gov.uk",
+        "content_type": "application/pdf",
+        "file_size": 175698,
+        "filename": "Grading-consultation-analysis-of-responses.pdf",
+        "number_of_pages": 24
+      }
+    ]
+  }
+}

--- a/examples/publication/frontend/publication-with-featured-attachments.json
+++ b/examples/publication/frontend/publication-with-featured-attachments.json
@@ -1,0 +1,294 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/government/publications/number-of-ex-regular-service-personnel-in-fr20",
+  "content_id": "5f5e1bb5-7631-11e4-a3cb-005056011aef",
+  "document_type": "foi_release",
+  "first_published_at": "2014-05-29T10:48:35.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2014-05-29T10:48:35.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": null,
+  "rendering_app": "government-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "publication",
+  "title": "Number of ex-regular service personnel in FR20",
+  "updated_at": "2020-03-12T18:18:24.794Z",
+  "withdrawn_notice": {
+  },
+  "publishing_request_id": "25419-1584037104.653-10.13.4.55-540",
+  "links": {
+    "government": [
+      {
+        "content_id": "591c83aa-3b74-437d-a342-612bddd97572",
+        "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+        "locale": "en",
+        "api_path": "/api/content/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "base_path": "/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2010-05-12T00:00:00+00:00",
+          "ended_on": "2015-05-08T00:00:00+00:00",
+          "current": false
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "web_url": "https://www.gov.uk/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "d994e55c-48c9-4795-b872-58d8ec98af12",
+        "title": "Ministry of Defence",
+        "locale": "en",
+        "analytics_identifier": "D17",
+        "api_path": "/api/content/government/organisations/ministry-of-defence",
+        "base_path": "/government/organisations/ministry-of-defence",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Ministry<br/>of Defence",
+            "crest": "mod"
+          },
+          "brand": "ministry-of-defence",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/154/s300_ministry-of-defence.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/154/s960_ministry-of-defence.jpg"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/ministry-of-defence",
+        "web_url": "https://www.gov.uk/government/organisations/ministry-of-defence"
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "d994e55c-48c9-4795-b872-58d8ec98af12",
+        "title": "Ministry of Defence",
+        "locale": "en",
+        "analytics_identifier": "D17",
+        "api_path": "/api/content/government/organisations/ministry-of-defence",
+        "base_path": "/government/organisations/ministry-of-defence",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Ministry<br/>of Defence",
+            "crest": "mod"
+          },
+          "brand": "ministry-of-defence",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/154/s300_ministry-of-defence.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/154/s960_ministry-of-defence.jpg"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/ministry-of-defence",
+        "web_url": "https://www.gov.uk/government/organisations/ministry-of-defence"
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "d994e55c-48c9-4795-b872-58d8ec98af12",
+        "title": "Ministry of Defence",
+        "locale": "en",
+        "analytics_identifier": "D17",
+        "api_path": "/api/content/government/organisations/ministry-of-defence",
+        "base_path": "/government/organisations/ministry-of-defence",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Ministry<br/>of Defence",
+            "crest": "mod"
+          },
+          "brand": "ministry-of-defence",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/154/s300_ministry-of-defence.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/154/s960_ministry-of-defence.jpg"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/ministry-of-defence",
+        "web_url": "https://www.gov.uk/government/organisations/ministry-of-defence"
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "e491505c-77ae-45b2-84be-8c94b94f6a2b",
+        "title": "Defence and armed forces",
+        "locale": "en",
+        "api_path": "/api/content/defence-and-armed-forces",
+        "base_path": "/defence-and-armed-forces",
+        "document_type": "taxon",
+        "public_updated_at": "2018-09-16T20:34:16Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Defence and armed forces",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "root_taxon": [
+            {
+              "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+              "title": "GOV.UK homepage",
+              "locale": "en",
+              "api_path": "/api/content/",
+              "base_path": "/",
+              "document_type": "homepage",
+              "public_updated_at": "2019-06-21T11:52:37Z",
+              "schema_name": "homepage",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/",
+              "web_url": "https://www.gov.uk/"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/defence-and-armed-forces",
+        "web_url": "https://www.gov.uk/defence-and-armed-forces"
+      },
+      {
+        "content_id": "8a98b827-82ad-49b4-819e-82c208c551c4",
+        "title": "National security",
+        "locale": "en",
+        "api_path": "/api/content/government/national-security",
+        "base_path": "/government/national-security",
+        "document_type": "taxon",
+        "public_updated_at": "2018-08-17T15:32:41Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "National security [PA]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "e48ab80a-de80-4e83-bf59-26316856a5f9",
+              "title": "Government",
+              "locale": "en",
+              "api_path": "/api/content/government/all",
+              "base_path": "/government/all",
+              "document_type": "taxon",
+              "public_updated_at": "2018-09-16T20:29:39Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Government",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": true
+              },
+              "phase": "live",
+              "links": {
+                "root_taxon": [
+                  {
+                    "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                    "title": "GOV.UK homepage",
+                    "locale": "en",
+                    "api_path": "/api/content/",
+                    "base_path": "/",
+                    "document_type": "homepage",
+                    "public_updated_at": "2019-06-21T11:52:37Z",
+                    "schema_name": "homepage",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/",
+                    "web_url": "https://www.gov.uk/"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/all",
+              "web_url": "https://www.gov.uk/government/all"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/national-security",
+        "web_url": "https://www.gov.uk/government/national-security"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Number of ex-regular service personnel in FR20",
+        "public_updated_at": "2014-05-29T10:48:35Z",
+        "document_type": "foi_release",
+        "schema_name": "publication",
+        "base_path": "/government/publications/number-of-ex-regular-service-personnel-in-fr20",
+        "api_path": "/api/content/government/publications/number-of-ex-regular-service-personnel-in-fr20",
+        "withdrawn": false,
+        "content_id": "5f5e1bb5-7631-11e4-a3cb-005056011aef",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/government/publications/number-of-ex-regular-service-personnel-in-fr20",
+        "web_url": "https://www.gov.uk/government/publications/number-of-ex-regular-service-personnel-in-fr20",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "MOD response to an FOI request for number of ex-regular service personnel part of Future Reserves 2020 (FR20).",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>MOD response to a Freedom of Information (FOI) request dated 14 February 2014 for the number of ex-regular service personnel who are now part of Future Reserves 2020 (FR20). It also includes the number of regular service personnel who were made redundant prior to joining the reserves.</p>\n</div>",
+    "change_history": [
+      {
+        "public_timestamp": "2014-05-29T11:48:35.000+01:00",
+        "note": "First published."
+      }
+    ],
+    "documents": [
+
+    ],
+    "featured_attachments": [
+      "PUBLIC_1392629965.pdf"
+    ],
+    "emphasised_organisations": [
+      "d994e55c-48c9-4795-b872-58d8ec98af12"
+    ],
+    "political": false,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "first_public_at": "2014-05-29T11:48:35.000+01:00",
+    "attachments": [
+      {
+        "attachment_type": "file",
+        "id": "PUBLIC_1392629965.pdf",
+        "title": "Number of ex-regular service personnel now part of FR20",
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+        "command_paper_number": "",
+        "hoc_paper_number": "",
+        "isbn": "",
+        "unique_reference": "",
+        "unnumbered_command_paper": false,
+        "unnumbered_hoc_paper": false,
+        "accessible": true,
+        "alternative_format_contact_email": "ddc-modinternet@mod.gov.uk",
+        "content_type": "application/pdf",
+        "file_size": 1932905,
+        "filename": "PUBLIC_1392629965.pdf",
+        "number_of_pages": 2
+      }
+    ]
+  }
+}


### PR DESCRIPTION
https://trello.com/c/wM9wqe9H/1587-support-featured-attachments-directly-on-govuk-frontend

Previously we relied on pre-rendered HTML for the attached 'documents'
of publications and consultations. This adds an example to support work
to directly render attachments based on metadata in the payload, and an
array of featured attachment IDs. See RFC 116 for more details.

https://github.com/alphagov/govuk-rfcs/blob/master/rfc-116-store-attachment-data-in-content-items.md