### PR TITLE
Add ministerial to roles

### DIFF
--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -107,6 +107,11 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ministerial": {
+          "description": "Link to the ministers index page, present if this is a ministerial role.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -127,6 +127,11 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ministerial": {
+          "description": "Link to the ministers index page, present if this is a ministerial role.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -236,6 +241,11 @@
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
+        },
+        "ministerial": {
+          "description": "Link to the ministers index page, present if this is a ministerial role.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -69,6 +69,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ministerial": {
+          "description": "Link to the ministers index page, present if this is a ministerial role.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "ordered_parent_organisations": {
           "description": "Organisations that own this role.",
           "$ref": "#/definitions/guid_list"

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -54,5 +54,9 @@
   },
   edition_links: (import "shared/base_edition_links.jsonnet") + {
     ordered_parent_organisations: "Organisations that own this role.",
+    ministerial: {
+      description: "Link to the ministers index page, present if this is a ministerial role.",
+      maxItems: 1,
+    },
   },
 }


### PR DESCRIPTION
If the role is ministerial we want to present the ministers index page.

Trello: https://trello.com/c/i1ffrXiZ/1913-5-link-ministers-to-the-government-ministers-content-item