### PR TITLE
Remove placeholder_working_group

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -143,7 +143,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -169,7 +169,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -153,7 +153,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -143,7 +143,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -169,7 +169,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -153,7 +153,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -143,7 +143,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -169,7 +169,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -153,7 +153,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -146,7 +146,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -172,7 +172,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -153,7 +153,6 @@
         "placeholder_person",
         "placeholder_policy_area",
         "placeholder_topical_event",
-        "placeholder_working_group",
         "placeholder_world_location",
         "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -107,7 +107,6 @@
 - placeholder_person
 - placeholder_policy_area
 - placeholder_topical_event
-- placeholder_working_group
 - placeholder_world_location
 - placeholder_world_location_news_page
 - placeholder_worldwide_organisation


### PR DESCRIPTION
This document type is not used and should now be removed.

Trello:
https://trello.com/c/ygOqmhWw/1921-remove-legacy-placeholderworkinggroup-code-data-from-govuks-codebase