### PR TITLE
Add phase_message optional field

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -626,6 +637,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -261,6 +272,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -195,6 +195,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -274,6 +277,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -318,6 +318,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -390,6 +393,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -764,6 +775,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -395,6 +406,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -629,6 +640,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -264,6 +275,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -721,6 +732,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -356,6 +367,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -203,6 +203,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -290,6 +293,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -331,6 +331,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -411,6 +414,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -859,6 +870,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -127,6 +127,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -212,6 +215,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -521,6 +532,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -187,6 +187,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -302,6 +302,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -378,6 +381,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -873,6 +884,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -80,6 +80,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -161,6 +164,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -493,6 +504,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -619,6 +630,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -254,6 +265,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -209,6 +209,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -293,6 +296,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -326,6 +326,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -403,6 +406,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -814,6 +825,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -125,6 +125,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -207,6 +210,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -479,6 +490,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -196,6 +196,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -275,6 +278,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -319,6 +319,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -391,6 +394,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -857,6 +868,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -84,6 +84,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -161,6 +164,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -488,6 +499,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -197,6 +197,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -276,6 +279,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -322,6 +322,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -394,6 +397,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -764,6 +775,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -115,6 +115,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -192,6 +195,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -423,6 +434,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -690,6 +701,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -325,6 +336,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/external_content/notification/schema.json
+++ b/dist/formats/external_content/notification/schema.json
@@ -158,6 +158,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -227,6 +230,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -491,6 +502,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -77,6 +77,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -146,6 +149,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -254,6 +265,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -128,6 +128,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -201,6 +204,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -184,6 +184,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -260,6 +263,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -596,6 +607,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -80,6 +80,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -161,6 +164,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -334,6 +345,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/facet_group/frontend/schema.json
+++ b/dist/formats/facet_group/frontend/schema.json
@@ -123,6 +123,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -196,6 +199,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/facet_group/notification/schema.json
+++ b/dist/formats/facet_group/notification/schema.json
@@ -174,6 +174,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -250,6 +253,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -525,6 +536,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -80,6 +80,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -161,6 +164,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -273,6 +284,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -366,6 +369,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -645,6 +656,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -80,6 +80,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -161,6 +164,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -277,6 +288,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -197,6 +197,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -276,6 +279,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -323,6 +323,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -395,6 +398,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -682,6 +693,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -113,6 +113,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -190,6 +193,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -338,6 +349,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -192,6 +192,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -265,6 +268,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -315,6 +315,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -381,6 +384,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -1017,6 +1028,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -84,6 +84,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -155,6 +158,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -628,6 +639,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -183,6 +183,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -256,6 +259,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -294,6 +294,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -360,6 +363,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -799,6 +810,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -430,6 +441,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -352,6 +352,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -425,6 +428,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -461,6 +461,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -527,6 +530,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -790,6 +801,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -254,6 +254,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -325,6 +328,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -425,6 +436,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -352,6 +352,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -425,6 +428,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -461,6 +461,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -527,6 +530,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -816,6 +827,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -254,6 +254,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -325,6 +328,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -451,6 +462,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -115,6 +115,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -185,6 +188,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -140,6 +140,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -213,6 +216,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -472,6 +483,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -74,6 +74,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -152,6 +155,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -255,6 +266,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/government/frontend/schema.json
+++ b/dist/formats/government/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/government/notification/schema.json
+++ b/dist/formats/government/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -633,6 +644,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/government/publisher_v2/schema.json
+++ b/dist/formats/government/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -268,6 +279,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -737,6 +748,25 @@
             "type": "string"
           },
           "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
             "type": "string"
           }
         }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -372,6 +383,25 @@
             "type": "string"
           },
           "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
             "type": "string"
           }
         }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -743,6 +754,25 @@
       "properties": {
         "base_path": {
           "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -378,6 +389,25 @@
       "properties": {
         "base_path": {
           "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
         }
       }
     },

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -120,6 +120,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -193,6 +196,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -167,6 +167,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -233,6 +236,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -495,6 +506,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -84,6 +84,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -155,6 +158,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -254,6 +265,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -178,6 +178,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -257,6 +260,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -284,6 +284,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -663,6 +674,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -98,6 +98,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -175,6 +178,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -319,6 +330,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -115,6 +115,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -188,6 +191,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -158,6 +158,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -224,6 +227,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -480,6 +491,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -79,6 +79,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -150,6 +153,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -250,6 +261,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -197,6 +197,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -270,6 +273,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -322,6 +322,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -388,6 +391,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -667,6 +678,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -270,6 +281,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -182,6 +182,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -296,6 +296,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -182,6 +182,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -296,6 +296,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/ministers_index/frontend/schema.json
+++ b/dist/formats/ministers_index/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/ministers_index/notification/schema.json
+++ b/dist/formats/ministers_index/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -625,6 +636,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/dist/formats/ministers_index/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -260,6 +271,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -686,6 +697,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -321,6 +332,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -216,6 +216,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -295,6 +298,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -357,6 +357,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -429,6 +432,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -852,6 +863,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -120,6 +120,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -197,6 +200,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -481,6 +492,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -213,6 +213,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -292,6 +295,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -354,6 +354,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -426,6 +429,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -1121,6 +1132,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -115,6 +115,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -192,6 +195,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_note": {
       "description": "Change note for the most recent update",
@@ -724,6 +735,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "people": {
       "description": "A list of people. Turn into proper links once organisations, people and roles are fully migrated.",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -702,6 +713,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -337,6 +348,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -356,6 +356,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -428,6 +431,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -469,6 +469,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -534,6 +537,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -930,6 +941,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -258,6 +258,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -328,6 +331,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -561,6 +572,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -225,6 +225,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -312,6 +315,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -359,6 +359,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -439,6 +442,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -803,6 +814,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -149,6 +149,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -234,6 +237,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
@@ -459,6 +470,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "nation_applicability": {
       "description": "An object specifying the applicability of a particular nation.",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -118,6 +118,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -196,6 +199,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -143,6 +143,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -211,6 +214,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -432,6 +443,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -79,6 +79,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -152,6 +155,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -241,6 +252,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -202,6 +202,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -320,6 +320,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -102,6 +102,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -189,6 +189,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -262,6 +265,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -306,6 +306,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -382,6 +385,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -662,6 +673,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -88,6 +88,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -169,6 +172,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -286,6 +297,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -189,6 +189,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -273,6 +276,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -306,6 +306,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -383,6 +386,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -685,6 +696,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -165,6 +168,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -328,6 +339,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -619,6 +630,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -254,6 +265,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -185,6 +185,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -264,6 +267,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -298,6 +298,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -370,6 +373,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -639,6 +650,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -266,6 +277,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -668,6 +679,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -303,6 +314,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -193,6 +193,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -266,6 +269,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -314,6 +314,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -380,6 +383,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -653,6 +664,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -264,6 +275,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -355,6 +355,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -428,6 +431,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -464,6 +464,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -530,6 +533,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -763,6 +774,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -254,6 +254,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -325,6 +328,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -419,6 +430,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -203,6 +203,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -313,6 +313,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -118,6 +118,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -215,6 +215,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -294,6 +297,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -355,6 +355,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -427,6 +430,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -807,6 +818,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -86,6 +86,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -163,6 +166,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -404,6 +415,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -185,6 +185,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -264,6 +267,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -298,6 +298,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -370,6 +373,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -696,6 +707,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -92,6 +92,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -169,6 +172,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -356,6 +367,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -184,6 +184,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -257,6 +260,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -292,6 +292,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -358,6 +361,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -657,6 +668,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -87,6 +87,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -158,6 +161,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -294,6 +305,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -131,6 +131,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -190,6 +190,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -95,6 +95,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -675,6 +686,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -310,6 +321,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -197,6 +197,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -270,6 +273,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -322,6 +322,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -388,6 +391,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -662,6 +673,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -91,6 +91,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -162,6 +165,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -273,6 +284,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -185,6 +185,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -258,6 +261,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -298,6 +298,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -364,6 +367,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -633,6 +644,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -260,6 +271,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -633,6 +644,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -268,6 +279,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -184,6 +184,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -296,6 +296,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -184,6 +184,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -257,6 +260,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -296,6 +296,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -646,6 +657,25 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -275,6 +286,25 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -254,6 +257,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -356,6 +359,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -642,6 +653,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -154,6 +157,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -277,6 +288,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -143,6 +143,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -206,6 +209,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -422,6 +433,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -181,6 +181,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -260,6 +263,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -290,6 +290,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -362,6 +365,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -689,6 +700,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "description_optional": {
       "anyOf": [
@@ -324,6 +335,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -185,6 +185,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -258,6 +261,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
         }
       ]
     },

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -298,6 +298,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -374,6 +377,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -679,6 +690,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -85,6 +85,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -166,6 +169,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -308,6 +319,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -195,6 +195,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "anyOf": [
         {
@@ -274,6 +277,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "change_history": {
       "type": "array",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -318,6 +318,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "public_updated_at": {
       "$ref": "#/definitions/public_updated_at"
     },
@@ -390,6 +393,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -804,6 +815,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -83,6 +83,9 @@
         "live"
       ]
     },
+    "phase_message": {
+      "$ref": "#/definitions/body_html_and_govspeak"
+    },
     "previous_version": {
       "type": "string"
     },
@@ -160,6 +163,14 @@
     "body": {
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "change_history": {
       "type": "array",
@@ -435,6 +446,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/examples/guide/publisher_v2/guide.json
+++ b/examples/guide/publisher_v2/guide.json
@@ -5,6 +5,13 @@
   "schema_name": "guide",
   "document_type": "guide",
   "public_updated_at": "2014-12-02T10:28:58.000+00:00",
+  "phase": "beta",
+  "phase_message": [
+    {
+      "content_type": "text/html",
+      "content": "This is an optional different message to explain what the state means in this context which can take <a class=\"govuk-link\" href='https://www.gov.uk'>HTML</a>"
+    }
+  ],
   "publishing_app": "publisher",
   "rendering_app": "frontend",
   "routes": [

--- a/formats/shared/default_properties/all.jsonnet
+++ b/formats/shared/default_properties/all.jsonnet
@@ -23,6 +23,9 @@
       "live",
     ],
   },
+  phase_message: {
+    "$ref": "#/definitions/body_html_and_govspeak",
+  },
   publishing_app: {
     "$ref": "#/definitions/publishing_app_name",
   },


### PR DESCRIPTION
This PR adds support for a `phase_message` optional field for all content items.

This will be useful especially for the `publisher` app where we want to be able to set this for a given content item, rather than globally across an application.

Related to https://github.com/alphagov/publisher/pull/1250.