### PR TITLE
Allow multiple marine notice vessel types/topics

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2102,17 +2102,38 @@
           ]
         },
         "marine_notice_vessel_type": {
-          "type": "string",
-          "enum": [
-            "pleasure-vessels",
-            "small-commercial-vessels",
-            "cargo-vessels-over-24-metres",
-            "fishing-vessels-under-15-metres",
-            "fishing-vessels-15-24-metres",
-            "fishing-vessels-over-24-metres",
-            "high-speed-craft",
-            "large-yachts",
-            "passenger-vessels"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "pleasure-vessels",
+                  "small-commercial-vessels",
+                  "cargo-vessels-over-24-metres",
+                  "fishing-vessels-under-15-metres",
+                  "fishing-vessels-15-24-metres",
+                  "fishing-vessels-over-24-metres",
+                  "high-speed-craft",
+                  "large-yachts",
+                  "passenger-vessels"
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "enum": [
+                "pleasure-vessels",
+                "small-commercial-vessels",
+                "cargo-vessels-over-24-metres",
+                "fishing-vessels-under-15-metres",
+                "fishing-vessels-15-24-metres",
+                "fishing-vessels-over-24-metres",
+                "high-speed-craft",
+                "large-yachts",
+                "passenger-vessels"
+              ]
+            }
           ]
         }
       }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2075,17 +2075,38 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "marine_notice_topic": {
-          "type": "string",
-          "enum": [
-            "construction-and-equipment",
-            "crew-and-training",
-            "health-and-safety",
-            "environmental",
-            "navigation",
-            "radio-communications",
-            "registration",
-            "security-isps",
-            "survey-and-inspection"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "construction-and-equipment",
+                  "crew-and-training",
+                  "health-and-safety",
+                  "environmental",
+                  "navigation",
+                  "radio-communications",
+                  "registration",
+                  "security-isps",
+                  "survey-and-inspection"
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "enum": [
+                "construction-and-equipment",
+                "crew-and-training",
+                "health-and-safety",
+                "environmental",
+                "navigation",
+                "radio-communications",
+                "registration",
+                "security-isps",
+                "survey-and-inspection"
+              ]
+            }
           ]
         },
         "marine_notice_type": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2218,17 +2218,38 @@
           ]
         },
         "marine_notice_vessel_type": {
-          "type": "string",
-          "enum": [
-            "pleasure-vessels",
-            "small-commercial-vessels",
-            "cargo-vessels-over-24-metres",
-            "fishing-vessels-under-15-metres",
-            "fishing-vessels-15-24-metres",
-            "fishing-vessels-over-24-metres",
-            "high-speed-craft",
-            "large-yachts",
-            "passenger-vessels"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "pleasure-vessels",
+                  "small-commercial-vessels",
+                  "cargo-vessels-over-24-metres",
+                  "fishing-vessels-under-15-metres",
+                  "fishing-vessels-15-24-metres",
+                  "fishing-vessels-over-24-metres",
+                  "high-speed-craft",
+                  "large-yachts",
+                  "passenger-vessels"
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "enum": [
+                "pleasure-vessels",
+                "small-commercial-vessels",
+                "cargo-vessels-over-24-metres",
+                "fishing-vessels-under-15-metres",
+                "fishing-vessels-15-24-metres",
+                "fishing-vessels-over-24-metres",
+                "high-speed-craft",
+                "large-yachts",
+                "passenger-vessels"
+              ]
+            }
           ]
         }
       }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2191,17 +2191,38 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "marine_notice_topic": {
-          "type": "string",
-          "enum": [
-            "construction-and-equipment",
-            "crew-and-training",
-            "health-and-safety",
-            "environmental",
-            "navigation",
-            "radio-communications",
-            "registration",
-            "security-isps",
-            "survey-and-inspection"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "construction-and-equipment",
+                  "crew-and-training",
+                  "health-and-safety",
+                  "environmental",
+                  "navigation",
+                  "radio-communications",
+                  "registration",
+                  "security-isps",
+                  "survey-and-inspection"
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "enum": [
+                "construction-and-equipment",
+                "crew-and-training",
+                "health-and-safety",
+                "environmental",
+                "navigation",
+                "radio-communications",
+                "registration",
+                "security-isps",
+                "survey-and-inspection"
+              ]
+            }
           ]
         },
         "marine_notice_type": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1885,17 +1885,38 @@
           ]
         },
         "marine_notice_vessel_type": {
-          "type": "string",
-          "enum": [
-            "pleasure-vessels",
-            "small-commercial-vessels",
-            "cargo-vessels-over-24-metres",
-            "fishing-vessels-under-15-metres",
-            "fishing-vessels-15-24-metres",
-            "fishing-vessels-over-24-metres",
-            "high-speed-craft",
-            "large-yachts",
-            "passenger-vessels"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "pleasure-vessels",
+                  "small-commercial-vessels",
+                  "cargo-vessels-over-24-metres",
+                  "fishing-vessels-under-15-metres",
+                  "fishing-vessels-15-24-metres",
+                  "fishing-vessels-over-24-metres",
+                  "high-speed-craft",
+                  "large-yachts",
+                  "passenger-vessels"
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "enum": [
+                "pleasure-vessels",
+                "small-commercial-vessels",
+                "cargo-vessels-over-24-metres",
+                "fishing-vessels-under-15-metres",
+                "fishing-vessels-15-24-metres",
+                "fishing-vessels-over-24-metres",
+                "high-speed-craft",
+                "large-yachts",
+                "passenger-vessels"
+              ]
+            }
           ]
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1858,17 +1858,38 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "marine_notice_topic": {
-          "type": "string",
-          "enum": [
-            "construction-and-equipment",
-            "crew-and-training",
-            "health-and-safety",
-            "environmental",
-            "navigation",
-            "radio-communications",
-            "registration",
-            "security-isps",
-            "survey-and-inspection"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "construction-and-equipment",
+                  "crew-and-training",
+                  "health-and-safety",
+                  "environmental",
+                  "navigation",
+                  "radio-communications",
+                  "registration",
+                  "security-isps",
+                  "survey-and-inspection"
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "enum": [
+                "construction-and-equipment",
+                "crew-and-training",
+                "health-and-safety",
+                "environmental",
+                "navigation",
+                "radio-communications",
+                "registration",
+                "security-isps",
+                "survey-and-inspection"
+              ]
+            }
           ]
         },
         "marine_notice_type": {

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1827,17 +1827,38 @@
         ],
       },
       marine_notice_vessel_type: {
-        type: "string",
-        enum: [
-          "pleasure-vessels",
-          "small-commercial-vessels",
-          "cargo-vessels-over-24-metres",
-          "fishing-vessels-under-15-metres",
-          "fishing-vessels-15-24-metres",
-          "fishing-vessels-over-24-metres",
-          "high-speed-craft",
-          "large-yachts",
-          "passenger-vessels",
+        oneOf: [
+          {
+            type: "array",
+            items: {
+              type: "string",
+              enum: [
+                "pleasure-vessels",
+                "small-commercial-vessels",
+                "cargo-vessels-over-24-metres",
+                "fishing-vessels-under-15-metres",
+                "fishing-vessels-15-24-metres",
+                "fishing-vessels-over-24-metres",
+                "high-speed-craft",
+                "large-yachts",
+                "passenger-vessels",
+              ],
+            },
+          },
+          {
+            type: "string",
+            enum: [
+              "pleasure-vessels",
+              "small-commercial-vessels",
+              "cargo-vessels-over-24-metres",
+              "fishing-vessels-under-15-metres",
+              "fishing-vessels-15-24-metres",
+              "fishing-vessels-over-24-metres",
+              "high-speed-craft",
+              "large-yachts",
+              "passenger-vessels",
+            ],
+          },
         ],
       },
       marine_notice_topic: {

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1862,17 +1862,38 @@
         ],
       },
       marine_notice_topic: {
-        type: "string",
-        enum: [
-          "construction-and-equipment",
-          "crew-and-training",
-          "health-and-safety",
-          "environmental",
-          "navigation",
-          "radio-communications",
-          "registration",
-          "security-isps",
-          "survey-and-inspection",
+        oneOf: [
+          {
+            type: "array",
+            items: {
+              type: "string",
+              enum: [
+                "construction-and-equipment",
+                "crew-and-training",
+                "health-and-safety",
+                "environmental",
+                "navigation",
+                "radio-communications",
+                "registration",
+                "security-isps",
+                "survey-and-inspection",
+              ],
+            },
+          },
+          {
+            type: "string",
+            enum: [
+              "construction-and-equipment",
+              "crew-and-training",
+              "health-and-safety",
+              "environmental",
+              "navigation",
+              "radio-communications",
+              "registration",
+              "security-isps",
+              "survey-and-inspection",
+            ],
+          },
         ],
       },
       issued_date: {


### PR DESCRIPTION
[Marine notices](https://specialist-publisher.integration.publishing.service.gov.uk/marine-notices) should apparently be allowed to have multiple vessel types and topics.  There's no content for this yet, so it's fine to change.

Reviewing while ignoring whitespace might help.

I'll remove the part that allows single tagging once this has been successfully built/deployed.  It's required to be there for now otherwise the specialist publisher build fails

Half of https://github.com/alphagov/specialist-publisher/pull/1636