### PR TITLE
Remove calendars dependant app

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ REPOSITORY = 'govuk-content-schemas'
 
 def dependentApplications = [
   'calculators',
-  'calendars',
   'collections-publisher',
   'collections',
   'contacts',


### PR DESCRIPTION
The app has been retired.

[Trello Card](https://trello.com/c/SKT4BnIQ/1953-retire-the-calendars-app-%F0%9F%8D%90)