### PR TITLE
Remove email-signup links for manual examples

### DIFF
--- a/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
+++ b/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
@@ -53,23 +53,6 @@
         "web_url": "https://www.gov.uk/service-manual/service-standard/have-a-multidisciplinary-team"
       }
     ],
-    "email_alert_signup": [
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/service-manual/service-standard/email-signup",
-        "base_path": "/service-manual/service-standard/email-signup",
-        "content_id": "4a94ae54-5a47-40c1-b9aa-ff47dcaace85",
-        "description": null,
-        "document_type": "email_alert_signup",
-        "locale": "en",
-        "public_updated_at": "2016-08-17T10:52:00Z",
-        "schema_name": "email_alert_signup",
-        "title": "Service Manual – Service Standard",
-        "web_url": "http://www.gov.uk/service-manual/service-standard/email-signup",
-        "links": {
-        }
-      }
-    ],
     "available_translations": [
       {
         "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",

--- a/examples/service_manual_topic/frontend/service_manual_topic.json
+++ b/examples/service_manual_topic/frontend/service_manual_topic.json
@@ -92,24 +92,6 @@
         "web_url": "https://www.gov.uk/service-manual/test-topic",
         "locale": "en"
       }
-    ],
-    "email_alert_signup": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/service-manual/test-expanded-topic/email-signup",
-        "api_url": "https://www.gov.uk/api/content/service-manual/test-expanded-topic/email-signup",
-        "base_path": "/service-manual/test-expanded-topic/email-signup",
-        "content_id": "e57b21e6-2111-4a50-9ead-9c502cd40a3d",
-        "description": null,
-        "document_type": "email_alert_signup",
-        "locale": "en",
-        "public_updated_at": "2016-08-17T10:52:00Z",
-        "schema_name": "email_alert_signup",
-        "title": "Service Manual – Service Manual Test Expanded Topic",
-        "web_url": "https://www.gov.uk/service-manual/test-expanded-topic/email-signup",
-        "links": {
-        }
-      }
     ]
   },
   "description": "Service Manual Topic description",

--- a/examples/service_manual_topic/publisher_v2/service_manual_topic_links.json
+++ b/examples/service_manual_topic/publisher_v2/service_manual_topic_links.json
@@ -7,9 +7,6 @@
     "content_owners": [
       "fb87cca9-311e-4fd3-af42-03616164a407",
       "d6f49e7f-4f54-44e6-815b-ac3098a5f509"
-    ],
-    "email_alert_signup": [
-      "e57b21e6-2111-4a50-9ead-9c502cd40a3d"
     ]
   }
 }


### PR DESCRIPTION
https://trello.com/c/KNWv9Dgx/258-deprecate-and-remove-legacy-email-signup-pages

This removes legacy email-signup links from service manual examples,
since these formats no longer include them [1].

[1]: https://github.com/alphagov/service-manual-publisher/pull/813