### PR TITLE
Add Pregnancy and Breasfeeding Therapeutic Areas

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1131,6 +1131,7 @@
             "type": "string",
             "enum": [
               "anaesthesia-intensive-care",
+              "breastfeeding",
               "cancer",
               "cardiovascular-disease-lipidology",
               "dentistry",
@@ -1148,6 +1149,7 @@
               "ophthalmology",
               "paediatrics-neonatology",
               "pain-management-palliation",
+              "pregnancy",
               "psychiatry",
               "radiology-imaging",
               "respiratory-disease-allergy",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1234,6 +1234,7 @@
             "type": "string",
             "enum": [
               "anaesthesia-intensive-care",
+              "breastfeeding",
               "cancer",
               "cardiovascular-disease-lipidology",
               "dentistry",
@@ -1251,6 +1252,7 @@
               "ophthalmology",
               "paediatrics-neonatology",
               "pain-management-palliation",
+              "pregnancy",
               "psychiatry",
               "radiology-imaging",
               "respiratory-disease-allergy",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1040,6 +1040,7 @@
             "type": "string",
             "enum": [
               "anaesthesia-intensive-care",
+              "breastfeeding",
               "cancer",
               "cardiovascular-disease-lipidology",
               "dentistry",
@@ -1057,6 +1058,7 @@
               "ophthalmology",
               "paediatrics-neonatology",
               "pain-management-palliation",
+              "pregnancy",
               "psychiatry",
               "radiology-imaging",
               "respiratory-disease-allergy",

--- a/examples/finder/frontend/drug-safety-update.json
+++ b/examples/finder/frontend/drug-safety-update.json
@@ -17,6 +17,10 @@
             "value": "anaesthesia-intensive-care"
           },
           {
+            "label": "Breastfeeding",
+            "value": "breastfeeding"
+          },
+          {
             "label": "Cancer",
             "value": "cancer"
           },
@@ -83,6 +87,10 @@
           {
             "label": "Pain management and palliation",
             "value": "pain-management-palliation"
+          },
+          {
+            "label": "Pregnancy",
+            "value": "pregnancy"
           },
           {
             "label": "Psychiatry",

--- a/examples/specialist_document/frontend/drug-safety-update.json
+++ b/examples/specialist_document/frontend/drug-safety-update.json
@@ -120,6 +120,10 @@
                   "value": "anaesthesia-intensive-care"
                 },
                 {
+                  "label": "Breastfeeding",
+                  "value": "breastfeeding"
+                },
+                {
                   "label": "Cancer",
                   "value": "cancer"
                 },
@@ -186,6 +190,10 @@
                 {
                   "label": "Pain management and palliation",
                   "value": "pain-management-palliation"
+                },
+                {
+                  "label": "Pregnancy",
+                  "value": "pregnancy"
                 },
                 {
                   "label": "Psychiatry",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1078,6 +1078,7 @@
           type: "string",
           enum: [
             "anaesthesia-intensive-care",
+            "breastfeeding",
             "cancer",
             "cardiovascular-disease-lipidology",
             "dentistry",
@@ -1095,6 +1096,7 @@
             "ophthalmology",
             "paediatrics-neonatology",
             "pain-management-palliation",
+            "pregnancy",
             "psychiatry",
             "radiology-imaging",
             "respiratory-disease-allergy",


### PR DESCRIPTION
This refers to https://www.gov.uk/drug-safety-update which is edited by
MHRA (Medicines and Healthcare products Regulatory Agency) in
https://specialist-publisher.publishing.service.gov.uk/drug-safety-updates

This is needed because they are launching a major new, lengthy project
on medicines and pregnant women, so will have a lot more content in this
area going forward, and wish to allow users to group existing content on
these topics closely together.

The request to add these two Therapeutic Areas came through Zendesk:
https://govuk.zendesk.com/agent/tickets/4099517

Related PRs:
- https://github.com/alphagov/specialist-publisher/pull/1657
- https://github.com/alphagov/search-api/pull/2113