### PR TITLE
Add ministers index to allowed types

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -119,6 +119,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -145,6 +145,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -129,6 +129,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -119,6 +119,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -145,6 +145,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -129,6 +129,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/ministers_index/frontend/schema.json
+++ b/dist/formats/ministers_index/frontend/schema.json
@@ -34,7 +34,7 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "finder"
+        "ministers_index"
       ]
     },
     "first_published_at": {

--- a/dist/formats/ministers_index/notification/schema.json
+++ b/dist/formats/ministers_index/notification/schema.json
@@ -60,7 +60,7 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "finder"
+        "ministers_index"
       ]
     },
     "email_document_supertype": {

--- a/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/dist/formats/ministers_index/publisher_v2/schema.json
@@ -44,7 +44,7 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "finder"
+        "ministers_index"
       ]
     },
     "first_published_at": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -119,6 +119,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -145,6 +145,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -129,6 +129,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -122,6 +122,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -148,6 +148,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -129,6 +129,7 @@
         "membership",
         "military_role",
         "ministerial_role",
+        "ministers_index",
         "national",
         "national_statistics",
         "national_statistics_announcement",

--- a/formats/ministers_index.jsonnet
+++ b/formats/ministers_index.jsonnet
@@ -1,5 +1,5 @@
 (import "shared/default_format.jsonnet") + {
-  document_type: "finder",
+  document_type: "ministers_index",
   definitions: {
     details: {
       type: "object",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -83,6 +83,7 @@
 - membership
 - military_role
 - ministerial_role
+- ministers_index
 - national
 - national_statistics
 - national_statistics_announcement


### PR DESCRIPTION
I realised while writing tests for a new presenter in whitehall that the new
`ministers_index` schema had not been added to `allowed_types.yml`. This was
giving a `Factory not registered` error.

Presenter card for reference: https://trello.com/c/I92GWawi/2027-3-write-ministers-index-presenter