### PR TITLE
Remove redundant fields for finder email signup

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -307,14 +307,6 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
-        "combine_mode": {
-          "description": "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
-          "type": "string",
-          "enum": [
-            "",
-            "or"
-          ]
-        },
         "email_filter_by": {
           "oneOf": [
             {
@@ -389,9 +381,6 @@
             "content_purpose_supergroup": {
               "type": "string"
             },
-            "document_type": {
-              "type": "string"
-            },
             "format": {
               "type": "string"
             },
@@ -416,10 +405,6 @@
           "prechecked"
         ],
         "properties": {
-          "content_id": {
-            "description": "Content id corresponding to the facet value, required by the email-alert-api for constructing facet value linked subscriber lists.",
-            "type": "string"
-          },
           "filter_values": {
             "type": "array",
             "items": {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -411,14 +411,6 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
-        "combine_mode": {
-          "description": "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
-          "type": "string",
-          "enum": [
-            "",
-            "or"
-          ]
-        },
         "email_filter_by": {
           "oneOf": [
             {
@@ -493,9 +485,6 @@
             "content_purpose_supergroup": {
               "type": "string"
             },
-            "document_type": {
-              "type": "string"
-            },
             "format": {
               "type": "string"
             },
@@ -520,10 +509,6 @@
           "prechecked"
         ],
         "properties": {
-          "content_id": {
-            "description": "Content id corresponding to the facet value, required by the email-alert-api for constructing facet value linked subscriber lists.",
-            "type": "string"
-          },
           "filter_values": {
             "type": "array",
             "items": {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -177,14 +177,6 @@
         "beta": {
           "$ref": "#/definitions/finder_beta"
         },
-        "combine_mode": {
-          "description": "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
-          "type": "string",
-          "enum": [
-            "",
-            "or"
-          ]
-        },
         "email_filter_by": {
           "oneOf": [
             {
@@ -259,9 +251,6 @@
             "content_purpose_supergroup": {
               "type": "string"
             },
-            "document_type": {
-              "type": "string"
-            },
             "format": {
               "type": "string"
             },
@@ -286,10 +275,6 @@
           "prechecked"
         ],
         "properties": {
-          "content_id": {
-            "description": "Content id corresponding to the facet value, required by the email-alert-api for constructing facet value linked subscriber lists.",
-            "type": "string"
-          },
           "filter_values": {
             "type": "array",
             "items": {

--- a/examples/finder_email_signup/frontend/cma-cases-email-signup.json
+++ b/examples/finder_email_signup/frontend/cma-cases-email-signup.json
@@ -77,7 +77,7 @@
   "details": {
     "beta": false,
     "filter": {
-      "document_type": "cma_case"
+      "format": "cma_case"
     },
     "email_filter_facets": [
       {

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -166,9 +166,6 @@
             part_of_taxonomy_tree: {
               type: "string"
             },
-            document_type: {
-              type: "string"
-            },
             format: {
               type: "string"
             }

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -60,10 +60,6 @@
           key: {
             type: "string",
           },
-          content_id: {
-            type: "string",
-            description: "Content id corresponding to the facet value, required by the email-alert-api for constructing facet value linked subscriber lists.",
-          },
           radio_button_name: {
             type: "string",
           },

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -174,14 +174,6 @@
             }
           },
         },
-        combine_mode: {
-          type: "string",
-          description: "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",
-          enum: [
-            "",
-            "or",
-          ],
-        },
       },
     },
   },


### PR DESCRIPTION
https://trello.com/c/Qr1IO25y/363-audit-all-email-signup-pages-to-understand-why-they-exist

As part of uncovering the history of finder email signups,
I came across a number of fields that confused me because
they are no longer used. Although we could just mark them
as 'deprecated', I don't see any reason to avoid deleting
them altogether, which is what this PR does.

Please see the commits for more details.