### PR TITLE
Remove redundant "reject" field for finder signups

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -400,15 +400,6 @@
             }
           }
         },
-        "reject": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "content_purpose_supergroup": {
-              "type": "string"
-            }
-          }
-        },
         "subscription_list_title_prefix": {
           "$ref": "#/definitions/subscription_list_title_prefix"
         }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -504,15 +504,6 @@
             }
           }
         },
-        "reject": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "content_purpose_supergroup": {
-              "type": "string"
-            }
-          }
-        },
         "subscription_list_title_prefix": {
           "$ref": "#/definitions/subscription_list_title_prefix"
         }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -270,15 +270,6 @@
             }
           }
         },
-        "reject": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "content_purpose_supergroup": {
-              "type": "string"
-            }
-          }
-        },
         "subscription_list_title_prefix": {
           "$ref": "#/definitions/subscription_list_title_prefix"
         }

--- a/formats/finder_email_signup.jsonnet
+++ b/formats/finder_email_signup.jsonnet
@@ -174,15 +174,6 @@
             }
           },
         },
-        reject: {
-          type: "object",
-          additionalProperties: false,
-          properties: {
-            content_purpose_supergroup: {
-              type: "string",
-            },
-          },
-        },
         combine_mode: {
           type: "string",
           description: "Controls which logic facets on the subscriber list should be joined by. Default is blank which maps to 'and'",


### PR DESCRIPTION
https://trello.com/c/Qr1IO25y/363-audit-all-email-signup-pages-to-understand-why-they-exist

Depends on: https://github.com/alphagov/search-api/pull/2152

This is no longer used [1].

[1]: https://github.com/alphagov/search-api/pull/2152