### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,6 @@ task build: %i[
               validate_examples
             ]
 
-task default: [:build]
+task default: %w[lint build]
 
 Dir.glob("lib/tasks/*.rake").each { |r| import r }

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task :lint do
+  sh "bundle exec rubocop"
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)