### PR TITLE
Add new seniority optional field to details in the role schema

### DIFF
--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -353,6 +353,9 @@
             null
           ]
         },
+        "seniority": {
+          "type": "integer"
+        },
         "supports_historical_accounts": {
           "type": "boolean"
         }

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -474,6 +474,9 @@
             null
           ]
         },
+        "seniority": {
+          "type": "integer"
+        },
         "supports_historical_accounts": {
           "type": "boolean"
         }

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -233,6 +233,9 @@
             null
           ]
         },
+        "seniority": {
+          "type": "integer"
+        },
         "supports_historical_accounts": {
           "type": "boolean"
         }

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -49,6 +49,9 @@
         supports_historical_accounts: {
           type: "boolean",
         },
+        seniority :{
+          type: "integer",
+        },
       },
     },
   },


### PR DESCRIPTION
Add new `seniority` optional field to `details` in the role schema

Part of the work to migrate rendering of the government/ministers page
from whitehall to collections.

Detailed here: https://trello.com/c/T6u4LjxS/2062-3-add-sorting-information-to-ministers-content-item

and here: https://trello.com/c/loAlkIp7/1715-8-migrate-government-ministers-to-collections