### PR TITLE
Remove lintRuby jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,9 +60,9 @@ node {
       govuk.bundleApp();
     }
 
-    stage("Lint") {
-      govuk.lintRuby()
-    }
+    stage("Lint Ruby") {
+      govuk.runRakeTask("lint")
+    } 
 
     stage("Run tests") {
       govuk.runRakeTask("spec")


### PR DESCRIPTION
`lintRuby` was removed in an earlier govuk-jenkinslib PR
(alphagov/govuk-jenkinslib#74)

and has been seperately added to the default rake task for this repo
(#998)