### PR TITLE
Add example for 'tagged to two coronovirus taxons super breadcrumbs'

### DIFF
--- a/examples/publication/frontend/tagged_to_two_coronavirus_taxons.json
+++ b/examples/publication/frontend/tagged_to_two_coronavirus_taxons.json
@@ -1,0 +1,757 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/government/publications/further-businesses-and-premises-to-close",
+  "content_id": "84abddd2-bc91-49ab-ba0c-484f5725a8a0",
+  "document_type": "guidance",
+  "first_published_at": "2020-03-12T23:00:00.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2020-08-19T14:53:46.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": "2020-03-12T23:00:00.000+00:00",
+  "rendering_app": "government-frontend",
+  "scheduled_publishing_delay_seconds": 1,
+  "schema_name": "publication",
+  "title": "Closing certain businesses and venues in England",
+  "updated_at": "2020-08-21T14:22:15.498Z",
+  "withdrawn_notice": {
+  },
+  "publishing_request_id": "28025-1597848826.662-10.13.3.113-1935",
+  "links": {
+    "children": [
+      {
+        "content_id": "1a1993ca-974e-4058-9a11-538f2ee3a18c",
+        "title": "Closing certain businesses and venues in England",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/further-businesses-and-premises-to-close/closing-certain-businesses-and-venues-in-england",
+        "base_path": "/government/publications/further-businesses-and-premises-to-close/closing-certain-businesses-and-venues-in-england",
+        "document_type": "html_publication",
+        "public_updated_at": "2020-08-19T13:39:12Z",
+        "schema_name": "html_publication",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "content_id": "84abddd2-bc91-49ab-ba0c-484f5725a8a0",
+              "title": "Closing certain businesses and venues in England",
+              "locale": "en",
+              "api_path": "/api/content/government/publications/further-businesses-and-premises-to-close",
+              "base_path": "/government/publications/further-businesses-and-premises-to-close",
+              "document_type": "guidance",
+              "public_updated_at": "2020-08-19T14:53:46Z",
+              "schema_name": "publication",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/publications/further-businesses-and-premises-to-close",
+              "web_url": "https://www.integration.publishing.service.gov.uk/government/publications/further-businesses-and-premises-to-close"
+            }
+          ]
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/publications/further-businesses-and-premises-to-close/closing-certain-businesses-and-venues-in-england",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/publications/further-businesses-and-premises-to-close/closing-certain-businesses-and-venues-in-england"
+      }
+    ],
+    "government": [
+      {
+        "content_id": "d4fbc1b9-d47d-4386-af04-ac909f868f92",
+        "title": "2015 Conservative government",
+        "locale": "en",
+        "api_path": "/api/content/government/2015-conservative-government",
+        "base_path": "/government/2015-conservative-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2015-05-08T00:00:00+00:00",
+          "ended_on": null,
+          "current": true
+        },
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/2015-conservative-government",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/2015-conservative-government"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "locale": "en",
+        "analytics_identifier": "D2",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Cabinet Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/organisations/cabinet-office",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/organisations/cabinet-office"
+      },
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Ministry of Housing, Communities & Local Government",
+        "locale": "en",
+        "analytics_identifier": "D4",
+        "api_path": "/api/content/government/organisations/ministry-of-housing-communities-and-local-government",
+        "base_path": "/government/organisations/ministry-of-housing-communities-and-local-government",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Ministry of Housing,<br/>Communities &amp;<br/>Local Government"
+          },
+          "brand": "department-for-communities-and-local-government",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/124/s300_2_Marsham_Street_960x640.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/124/s960_2_Marsham_Street_960x640.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/organisations/ministry-of-housing-communities-and-local-government",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government"
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Ministry of Housing, Communities & Local Government",
+        "locale": "en",
+        "analytics_identifier": "D4",
+        "api_path": "/api/content/government/organisations/ministry-of-housing-communities-and-local-government",
+        "base_path": "/government/organisations/ministry-of-housing-communities-and-local-government",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Ministry of Housing,<br/>Communities &amp;<br/>Local Government"
+          },
+          "brand": "department-for-communities-and-local-government",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/124/s300_2_Marsham_Street_960x640.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/124/s960_2_Marsham_Street_960x640.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/organisations/ministry-of-housing-communities-and-local-government",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government"
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Ministry of Housing, Communities & Local Government",
+        "locale": "en",
+        "analytics_identifier": "D4",
+        "api_path": "/api/content/government/organisations/ministry-of-housing-communities-and-local-government",
+        "base_path": "/government/organisations/ministry-of-housing-communities-and-local-government",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Ministry of Housing,<br/>Communities &amp;<br/>Local Government"
+          },
+          "brand": "department-for-communities-and-local-government",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/124/s300_2_Marsham_Street_960x640.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/124/s960_2_Marsham_Street_960x640.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/organisations/ministry-of-housing-communities-and-local-government",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government"
+      }
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "221ae5f2-cb92-48e7-932f-73679659c15b",
+        "title": "COVID-19 guidance for mass gatherings",
+        "locale": "en",
+        "api_path": "/api/content/guidance/covid-19-guidance-for-mass-gatherings",
+        "base_path": "/guidance/covid-19-guidance-for-mass-gatherings",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2020-03-16T20:19:00Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/guidance/covid-19-guidance-for-mass-gatherings",
+        "web_url": "https://www.integration.publishing.service.gov.uk/guidance/covid-19-guidance-for-mass-gatherings"
+      },
+      {
+        "content_id": "00c39c07-4595-4927-8b81-64a4def8e596",
+        "title": "Reopen your business safely during coronavirus (COVID‑19)",
+        "locale": "en",
+        "api_path": "/api/content/coronavirus-business-reopening",
+        "base_path": "/coronavirus-business-reopening",
+        "document_type": "transaction",
+        "public_updated_at": "2020-08-19T15:10:56Z",
+        "schema_name": "transaction",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-business-reopening",
+        "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-business-reopening"
+      },
+      {
+        "content_id": "4854027d-66d0-4b6c-af68-080faeb724ce",
+        "title": "COVID-19: Guidance for the safe use of multi-purpose community facilities",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/covid-19-guidance-for-the-safe-use-of-multi-purpose-community-facilities",
+        "base_path": "/government/publications/covid-19-guidance-for-the-safe-use-of-multi-purpose-community-facilities",
+        "document_type": "guidance",
+        "public_updated_at": "2020-08-14T16:10:03Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/publications/covid-19-guidance-for-the-safe-use-of-multi-purpose-community-facilities",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/publications/covid-19-guidance-for-the-safe-use-of-multi-purpose-community-facilities"
+      },
+      {
+        "content_id": "9c2ee291-073b-43d4-bc55-aa287658d533",
+        "title": "31 July announcement",
+        "locale": "en",
+        "api_path": "/api/content/guidance/31-july-announcement",
+        "base_path": "/guidance/31-july-announcement",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2020-07-31T16:33:00Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/guidance/31-july-announcement",
+        "web_url": "https://www.integration.publishing.service.gov.uk/guidance/31-july-announcement"
+      },
+      {
+        "content_id": "90387e7a-0348-46fe-ac08-e5a77e87a2af",
+        "title": "Maintaining records of staff, customers and visitors to support NHS Test and Trace",
+        "locale": "en",
+        "api_path": "/api/content/guidance/maintaining-records-of-staff-customers-and-visitors-to-support-nhs-test-and-trace",
+        "base_path": "/guidance/maintaining-records-of-staff-customers-and-visitors-to-support-nhs-test-and-trace",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2020-07-02T19:24:00Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/guidance/maintaining-records-of-staff-customers-and-visitors-to-support-nhs-test-and-trace",
+        "web_url": "https://www.integration.publishing.service.gov.uk/guidance/maintaining-records-of-staff-customers-and-visitors-to-support-nhs-test-and-trace"
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "495afdb6-47be-4df1-8b38-91c8adb1eefc",
+        "title": "Business and industry",
+        "locale": "en",
+        "api_path": "/api/content/business-and-industry",
+        "base_path": "/business-and-industry",
+        "document_type": "taxon",
+        "public_updated_at": "2018-09-03T15:41:02Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Business and industry",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "root_taxon": [
+            {
+              "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+              "title": "GOV.UK homepage",
+              "locale": "en",
+              "api_path": "/api/content/",
+              "base_path": "/",
+              "document_type": "homepage",
+              "public_updated_at": "2019-06-21T11:52:37Z",
+              "schema_name": "homepage",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.integration.publishing.service.gov.uk/api/content/",
+              "web_url": "https://www.integration.publishing.service.gov.uk/"
+            }
+          ]
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/business-and-industry",
+        "web_url": "https://www.integration.publishing.service.gov.uk/business-and-industry"
+      },
+      {
+        "content_id": "e09f83b0-a87b-4012-af78-a604d880cea9",
+        "title": "Business closures during coronavirus",
+        "locale": "en",
+        "api_path": "/api/content/coronavirus-taxon/business-closures",
+        "base_path": "/coronavirus-taxon/business-closures",
+        "document_type": "taxon",
+        "public_updated_at": "2020-05-20T10:34:07Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Business closures during coronavirus",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "65666cdf-b177-4d79-9687-b9c32805e450",
+              "title": "Support for businesses and self-employed people during coronavirus",
+              "locale": "en",
+              "api_path": "/api/content/coronavirus-taxon/businesses-and-self-employed-people",
+              "base_path": "/coronavirus-taxon/businesses-and-self-employed-people",
+              "document_type": "taxon",
+              "public_updated_at": "2020-05-20T10:31:25Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Support for businesses and self-employed people during coronavirus ",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "5b7b9532-a775-4bd2-a3aa-6ce380184b6c",
+                    "title": "Coronavirus (COVID-19)",
+                    "locale": "en",
+                    "api_path": "/api/content/coronavirus-taxon",
+                    "base_path": "/coronavirus-taxon",
+                    "document_type": "taxon",
+                    "public_updated_at": "2020-05-19T06:54:07Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "",
+                    "details": {
+                      "internal_name": "Coronavirus (COVID-19)",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": true
+                    },
+                    "phase": "live",
+                    "links": {
+                      "root_taxon": [
+                        {
+                          "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                          "title": "GOV.UK homepage",
+                          "locale": "en",
+                          "api_path": "/api/content/",
+                          "base_path": "/",
+                          "document_type": "homepage",
+                          "public_updated_at": "2019-06-21T11:52:37Z",
+                          "schema_name": "homepage",
+                          "withdrawn": false,
+                          "links": {
+                          },
+                          "api_url": "https://www.integration.publishing.service.gov.uk/api/content/",
+                          "web_url": "https://www.integration.publishing.service.gov.uk/"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon",
+                    "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon"
+                  }
+                ]
+              },
+              "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon/businesses-and-self-employed-people",
+              "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon/businesses-and-self-employed-people"
+            }
+          ]
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon/business-closures",
+        "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon/business-closures"
+      },
+      {
+        "content_id": "56b3b4d6-7124-4c7f-8d21-432c93691728",
+        "title": "Managing your business during coronavirus",
+        "locale": "en",
+        "api_path": "/api/content/coronavirus-taxon/managing-your-business-during-coronavirus",
+        "base_path": "/coronavirus-taxon/managing-your-business-during-coronavirus",
+        "document_type": "taxon",
+        "public_updated_at": "2020-05-19T06:54:07Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Managing your business during coronavirus",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "65666cdf-b177-4d79-9687-b9c32805e450",
+              "title": "Support for businesses and self-employed people during coronavirus",
+              "locale": "en",
+              "api_path": "/api/content/coronavirus-taxon/businesses-and-self-employed-people",
+              "base_path": "/coronavirus-taxon/businesses-and-self-employed-people",
+              "document_type": "taxon",
+              "public_updated_at": "2020-05-20T10:31:25Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Support for businesses and self-employed people during coronavirus ",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "5b7b9532-a775-4bd2-a3aa-6ce380184b6c",
+                    "title": "Coronavirus (COVID-19)",
+                    "locale": "en",
+                    "api_path": "/api/content/coronavirus-taxon",
+                    "base_path": "/coronavirus-taxon",
+                    "document_type": "taxon",
+                    "public_updated_at": "2020-05-19T06:54:07Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "",
+                    "details": {
+                      "internal_name": "Coronavirus (COVID-19)",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": true
+                    },
+                    "phase": "live",
+                    "links": {
+                      "root_taxon": [
+                        {
+                          "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                          "title": "GOV.UK homepage",
+                          "locale": "en",
+                          "api_path": "/api/content/",
+                          "base_path": "/",
+                          "document_type": "homepage",
+                          "public_updated_at": "2019-06-21T11:52:37Z",
+                          "schema_name": "homepage",
+                          "withdrawn": false,
+                          "links": {
+                          },
+                          "api_url": "https://www.integration.publishing.service.gov.uk/api/content/",
+                          "web_url": "https://www.integration.publishing.service.gov.uk/"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon",
+                    "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon"
+                  }
+                ]
+              },
+              "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon/businesses-and-self-employed-people",
+              "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon/businesses-and-self-employed-people"
+            }
+          ]
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon/managing-your-business-during-coronavirus",
+        "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon/managing-your-business-during-coronavirus"
+      },
+      {
+        "content_id": "d6a4884e-769d-4b81-8ba5-b64394362d92",
+        "title": "Public health",
+        "locale": "en",
+        "api_path": "/api/content/health-and-social-care/public-health",
+        "base_path": "/health-and-social-care/public-health",
+        "document_type": "taxon",
+        "public_updated_at": "2018-09-17T15:15:14Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Public health",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8",
+              "title": "Health and social care",
+              "locale": "en",
+              "api_path": "/api/content/health-and-social-care",
+              "base_path": "/health-and-social-care",
+              "document_type": "taxon",
+              "public_updated_at": "2018-09-16T20:30:51Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Health and social care",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": true
+              },
+              "phase": "live",
+              "links": {
+                "root_taxon": [
+                  {
+                    "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                    "title": "GOV.UK homepage",
+                    "locale": "en",
+                    "api_path": "/api/content/",
+                    "base_path": "/",
+                    "document_type": "homepage",
+                    "public_updated_at": "2019-06-21T11:52:37Z",
+                    "schema_name": "homepage",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.integration.publishing.service.gov.uk/api/content/",
+                    "web_url": "https://www.integration.publishing.service.gov.uk/"
+                  }
+                ]
+              },
+              "api_url": "https://www.integration.publishing.service.gov.uk/api/content/health-and-social-care",
+              "web_url": "https://www.integration.publishing.service.gov.uk/health-and-social-care"
+            }
+          ]
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/health-and-social-care/public-health",
+        "web_url": "https://www.integration.publishing.service.gov.uk/health-and-social-care/public-health"
+      },
+      {
+        "content_id": "b7f57213-4b16-446d-8ded-81955d782680",
+        "title": "Work and financial support during coronavirus",
+        "locale": "en",
+        "api_path": "/api/content/coronavirus-taxon/work-and-financial-support",
+        "base_path": "/coronavirus-taxon/work-and-financial-support",
+        "document_type": "taxon",
+        "public_updated_at": "2020-06-09T09:02:39Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Work and financial support during coronavirus",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "5b7b9532-a775-4bd2-a3aa-6ce380184b6c",
+              "title": "Coronavirus (COVID-19)",
+              "locale": "en",
+              "api_path": "/api/content/coronavirus-taxon",
+              "base_path": "/coronavirus-taxon",
+              "document_type": "taxon",
+              "public_updated_at": "2020-05-19T06:54:07Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Coronavirus (COVID-19)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": true
+              },
+              "phase": "live",
+              "links": {
+                "root_taxon": [
+                  {
+                    "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                    "title": "GOV.UK homepage",
+                    "locale": "en",
+                    "api_path": "/api/content/",
+                    "base_path": "/",
+                    "document_type": "homepage",
+                    "public_updated_at": "2019-06-21T11:52:37Z",
+                    "schema_name": "homepage",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.integration.publishing.service.gov.uk/api/content/",
+                    "web_url": "https://www.integration.publishing.service.gov.uk/"
+                  }
+                ]
+              },
+              "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon",
+              "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon"
+            }
+          ]
+        },
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus-taxon/work-and-financial-support",
+        "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus-taxon/work-and-financial-support"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Closing certain businesses and venues in England",
+        "public_updated_at": "2020-08-19T14:53:46Z",
+        "document_type": "guidance",
+        "schema_name": "publication",
+        "base_path": "/government/publications/further-businesses-and-premises-to-close",
+        "api_path": "/api/content/government/publications/further-businesses-and-premises-to-close",
+        "withdrawn": false,
+        "content_id": "84abddd2-bc91-49ab-ba0c-484f5725a8a0",
+        "locale": "en",
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/publications/further-businesses-and-premises-to-close",
+        "web_url": "https://www.integration.publishing.service.gov.uk/government/publications/further-businesses-and-premises-to-close",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "Guidance on the closure of certain businesses and venues as part of further social distancing measures, and on the further easing of coronavirus (COVID-19) restrictions in July and August 2020.",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>This document supports the government’s guidance on staying at home. It provides full guidance on the government’s announcement made on 23 March 2020 and the list of businesses and premises expected to close.</p> <p>The Designation letter applies to both the Health Protection (Coronavirus, Restrictions) (No. 2) (England) Regulations 2020 and the Health Protection (Coronavirus, Restrictions) (Leicester) Regulations 2020.</p> </div>",
+    "tags": {
+      "topics": [
+
+      ],
+      "browse_pages": [
+
+      ]
+    },
+    "documents": [
+      "<section class=\"attachment embedded\" id=\"attachment_23432\">\n<div class=\"attachment-thumb\">\n<a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/14664/2247515.pdf\"><img alt=\"\" src=\"https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/14664/thumbnail_2247515.pdf.png\"></a>\n</div>\n<div class=\"attachment-details\">\n<h2 class=\"title\"><a aria-describedby=\"attachment-23432-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/14664/2247515.pdf\">Affordable Housing Supply, England, 2011-2012</a></h2>\n<p class=\"metadata\">\n<span class=\"references\">\nRef: ISBN <span class=\"isbn\">9781409836872</span>\n</span>\n<span class=\"type\"><abbr title=\"Portable Document Format\">PDF</abbr></span>, <span class=\"file-size\">340KB</span>, <span class=\"page-length\">17 pages</span>\n</p>\n\n\n<div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-23432-accessibility-help\">\n<h2>This file may not be suitable for users of assistive technology.\n<a class=\"toggler\" href=\"#attachment-23432-accessibility-request\" data-controls=\"attachment-23432-accessibility-request\" data-expanded=\"false\" role=\"button\" aria-controls=\"attachment-23432-accessibility-request\" aria-expanded=\"false\">Request a different format.</a>\n</h2>\n<p id=\"attachment-23432-accessibility-request\" class=\"js-hidden\" aria-live=\"polite\" role=\"region\">\nIf you use assistive technology and need a version of this document\nin a more accessible format, please email\n<a href=\"mailto:alternativeformats@communities.gsi.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Affordable%20Housing%20Supply%2C%20England%2C%202011-2012%0A%20%20Original%20format%3A%20pdf%0A%20%20ISBN%3A%209781409836872%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Affordable%20Housing%20Supply%2C%20England%2C%202011-2012%27%20in%20an%20alternative%20format\">alternativeformats@communities.gsi.gov.uk</a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n</p>\n</div>\n</div>\n</section>"
+    ],
+    "political": false,
+    "change_history": [
+      {
+        "note": "Updated to reflect changes in rules on wearing face coverings.",
+        "public_timestamp": "2020-08-19T15:53:46.000+01:00"
+      },
+      {
+        "note": "Updated PDF ",
+        "public_timestamp": "2020-08-13T23:41:14.000+01:00"
+      },
+      {
+        "note": "Updated to reflect additional requirements on face coverings and amendments to 1 August 2020 easings.",
+        "public_timestamp": "2020-08-03T15:57:15.000+01:00"
+      },
+      {
+        "note": "Updated to show further easing of restrictions for more businesses and venues to reopen from 25 July and 1 August.",
+        "public_timestamp": "2020-07-17T14:36:13.000+01:00"
+      },
+      {
+        "note": "Updated to include easing of restrictions applying from 11 and 13 July",
+        "public_timestamp": "2020-07-09T19:07:18.000+01:00"
+      },
+      {
+        "note": "Guidance on closing certain businesses and venues in England updated following the announcement of further easing of coronavirus (COVID-19) restrictions from 4 July 2020.",
+        "public_timestamp": "2020-07-03T22:20:15.000+01:00"
+      },
+      {
+        "note": "Added Designation letter which applies to both the Health Protection (Coronavirus, Restrictions) (No. 2) (England) Regulations 2020 and the Health Protection (Coronavirus, Restrictions) (Leicester) Regulations 2020.",
+        "public_timestamp": "2020-07-03T13:51:40.000+01:00"
+      },
+      {
+        "note": "Guidance updated to reflect current regulations.",
+        "public_timestamp": "2020-06-15T17:06:22.000+01:00"
+      },
+      {
+        "note": "Guidance updated to reflect current regulations.",
+        "public_timestamp": "2020-06-05T19:24:15.000+01:00"
+      },
+      {
+        "note": "Guidance updated to reflect current regulations.",
+        "public_timestamp": "2020-05-13T00:00:00.000+01:00"
+      },
+      {
+        "note": "The 'Closing certain businesses and venues in England' guidelines have been updated to further clarify the requirements of The Health Protection (Coronavirus) Regulations 2020",
+        "public_timestamp": "2020-05-01T14:11:30.000+01:00"
+      },
+      {
+        "note": "Updated designation letter including additional details on which authorities are designated under the Health Protection (Coronavirus, Restrictions) (England) Regulations 2020. ",
+        "public_timestamp": "2020-04-09T13:55:19.000+01:00"
+      },
+      {
+        "note": "Updated compliance section",
+        "public_timestamp": "2020-03-27T16:53:05.000+00:00"
+      },
+      {
+        "note": "Guidance amended to reflect the updated regulations.",
+        "public_timestamp": "2020-03-26T21:39:30.000+00:00"
+      },
+      {
+        "note": "Updated guidance.",
+        "public_timestamp": "2020-03-26T10:20:42.000+00:00"
+      },
+      {
+        "note": "Added guidance on work carried out in people’s homes and additional details to the list of businesses and premises that must remain closed.",
+        "public_timestamp": "2020-03-25T06:28:09.000+00:00"
+      },
+      {
+        "note": "First published.",
+        "public_timestamp": "2020-03-23T22:31:00.000+00:00"
+      }
+    ],
+    "first_public_at": "2020-03-23T22:31:00.000+00:00",
+    "featured_attachments": [
+      "4446737",
+      "4446738",
+      "4446739"
+    ],
+    "national_applicability": {
+      "wales": {
+        "label": "Wales",
+        "applicable": false,
+        "alternative_url": ""
+      },
+      "england": {
+        "label": "England",
+        "applicable": true
+      },
+      "scotland": {
+        "label": "Scotland",
+        "applicable": false,
+        "alternative_url": ""
+      },
+      "northern_ireland": {
+        "label": "Northern Ireland",
+        "applicable": false,
+        "alternative_url": ""
+      }
+    },
+    "emphasised_organisations": [
+      "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+    ]
+  }
+}


### PR DESCRIPTION
When Coronavirus content is tagged to more than one taxon, we chose only one to use as the 'superbreadcrumb'.

This example sets up some content tagged to two different coronavius taxons:
- b7f57213-4b16-446d-8ded-81955d782680 "Work and financial support during coronavirus"
- 65666cdf-b177-4d79-9687-b9c32805e450 "Support for businesses and self-employed people during coronavirus"