### PR TITLE
Add device-safety-information

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2144,7 +2144,8 @@
             "devices",
             "field-safety-notices",
             "company-led-drugs",
-            "national-patient-safety"
+            "national-patient-safety",
+            "device-safety-information"
           ]
         },
         "bulk_published": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2260,7 +2260,8 @@
             "devices",
             "field-safety-notices",
             "company-led-drugs",
-            "national-patient-safety"
+            "national-patient-safety",
+            "device-safety-information"
           ]
         },
         "bulk_published": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1927,7 +1927,8 @@
             "devices",
             "field-safety-notices",
             "company-led-drugs",
-            "national-patient-safety"
+            "national-patient-safety",
+            "device-safety-information"
           ]
         },
         "bulk_published": {

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1885,7 +1885,8 @@
           "devices",
           "field-safety-notices",
           "company-led-drugs",
-          "national-patient-safety"
+          "national-patient-safety",
+          "device-safety-information",
         ],
       },
       medical_specialism: {


### PR DESCRIPTION
This is an alert type for medical safety alerts which MHRA would like to start using with 1cd19d5 to replace "Medical Device Alert".

[Trello Card](https://trello.com/c/gnHVgWtw/2131-add-national-patient-safety-alerts) &middot; [Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/4210399)