### PR TITLE
Add whip organisation to role schema

### DIFF
--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -358,6 +358,23 @@
         },
         "supports_historical_accounts": {
           "type": "boolean"
+        },
+        "whip_organisation": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sort_order": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
         }
       }
     },

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -479,6 +479,23 @@
         },
         "supports_historical_accounts": {
           "type": "boolean"
+        },
+        "whip_organisation": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sort_order": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
         }
       }
     },

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -238,6 +238,23 @@
         },
         "supports_historical_accounts": {
           "type": "boolean"
+        },
+        "whip_organisation": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sort_order": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
         }
       }
     },

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -49,8 +49,25 @@
         supports_historical_accounts: {
           type: "boolean",
         },
-        seniority :{
+        seniority: {
           type: "integer",
+        },
+        whip_organisation: {
+          type: "object",
+          properties: {
+            sort_order: {
+              type: [
+                "integer",
+                "null",
+              ],
+            },
+            label: {
+              type: [
+                "string",
+                "null",
+              ],
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
Part of the work to migrate rendering of the government/ministers page from
whitehall to collections.

https://trello.com/c/loAlkIp7/2063-8-migrate-government-ministers-to-collections

This change is needed as I have added a new field to the `details` in
`role_presenter`, this change adds that field to ensure tests on CI pass.