### PR TITLE
Upgrade ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source "https://rubygems.org"
 
 gem "json-schema"
-gem "jsonnet", "~> 0.2"
+gem "jsonnet"
 gem "rake"
 gem "rspec"
 
 # Preview app for examples
-gem "govuk_schemas", "~> 3.2.0"
-gem "rack-test", "~> 0.8.2"
-gem "sinatra", "~> 2.0"
+gem "govuk_schemas"
+gem "rack-test"
+gem "sinatra"
 
 group :test do
   gem "pry-byebug"
 end
 
 group :development, :test do
-  gem "rubocop-govuk", "~> 3.3.0"
+  gem "rubocop-govuk"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby File.read(".ruby-version").strip
 
 gem "json-schema"
 gem "jsonnet", "~> 0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,4 +91,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,15 +80,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_schemas (~> 3.2.0)
+  govuk_schemas
   json-schema
-  jsonnet (~> 0.2)
+  jsonnet
   pry-byebug
-  rack-test (~> 0.8.2)
+  rack-test
   rake
   rspec
-  rubocop-govuk (~> 3.3.0)
-  sinatra (~> 2.0)
+  rubocop-govuk
+  sinatra
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,8 +90,5 @@ DEPENDENCIES
   rubocop-govuk (~> 3.3.0)
   sinatra (~> 2.0)
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.2

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,15 @@ begin
 rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
+desc "regenerate schemas and validate"
 task build: %i[
-              regenerate_schemas
-              validate_dist_schemas
-              validate_uniqueness_of_frontend_example_base_paths
-              validate_links
-              format_examples
-              validate_examples
-            ]
+  regenerate_schemas
+  validate_dist_schemas
+  validate_uniqueness_of_frontend_example_base_paths
+  validate_links
+  format_examples
+  validate_examples
+]
 
 task default: %w[lint build]
 

--- a/lib/schema_generator/definitions_resolver.rb
+++ b/lib/schema_generator/definitions_resolver.rb
@@ -48,7 +48,7 @@ module SchemaGenerator
     def resolve_depenencies(definition_names, dependencies_found = [])
       names = definition_names.flat_map do |name|
         dependencies = definition_dependencies[name]
-        raise UnresolvedDefinition.new(name) unless dependencies
+        raise UnresolvedDefinition, name unless dependencies
 
         new_dependencies = dependencies - dependencies_found
         current_dependencies = dependencies_found + new_dependencies

--- a/lib/schema_generator/expanded_links.rb
+++ b/lib/schema_generator/expanded_links.rb
@@ -1,58 +1,58 @@
 module SchemaGenerator
   class ExpandedLinks
     LINK_TYPES_ADDED_BY_PUBLISHING_API = {
-     # The Publishing API will automatically link to any translations (content
-     # with the same content_id but a different locale).
-     "available_translations" => "frontend_links_with_base_path",
+      # The Publishing API will automatically link to any translations (content
+      # with the same content_id but a different locale).
+      "available_translations" => "frontend_links_with_base_path",
 
-     # Content items that are linked to with a `parent` link type will automatically
-     # have a `children` link type with those items.
-     "children" => "frontend_links_with_base_path",
+      # Content items that are linked to with a `parent` link type will automatically
+      # have a `children` link type with those items.
+      "children" => "frontend_links_with_base_path",
 
-     # Working groups have a `policies` link type containing the policies it is
-     # tagged to.
-     "policies" => "frontend_links_with_base_path",
+      # Working groups have a `policies` link type containing the policies it is
+      # tagged to.
+      "policies" => "frontend_links_with_base_path",
 
-     # Content items that are members of a collection will have a `document_collections`
-     # link type
-     "document_collections" => "frontend_links_with_base_path",
+      # Content items that are members of a collection will have a `document_collections`
+      # link type
+      "document_collections" => "frontend_links_with_base_path",
 
-     # Content items that are linked to with a `parent_taxon` link type will automatically
-     # have a `child_taxon` link type with those items.
-     "child_taxons" => "frontend_links_with_base_path",
+      # Content items that are linked to with a `parent_taxon` link type will automatically
+      # have a `child_taxon` link type with those items.
+      "child_taxons" => "frontend_links_with_base_path",
 
-     # Taxons with a 'root_taxon' link are considered level one taxons and are linked to
-     # the homepage. The homepage in turn has 'level_one_taxons' automatically added linking
-     # back to the taxon.
-     "level_one_taxons" => "frontend_links_with_base_path",
+      # Taxons with a 'root_taxon' link are considered level one taxons and are linked to
+      # the homepage. The homepage in turn has 'level_one_taxons' automatically added linking
+      # back to the taxon.
+      "level_one_taxons" => "frontend_links_with_base_path",
 
-     # The are content items that can include step by step navigation.  They are linked
-     # to by the `pages_part_of_step_nav` link type on a step_by_step_navigation page.
-     "part_of_step_navs" => "frontend_links_with_base_path",
+      # The are content items that can include step by step navigation.  They are linked
+      # to by the `pages_part_of_step_nav` link type on a step_by_step_navigation page.
+      "part_of_step_navs" => "frontend_links_with_base_path",
 
-     # These are content items that are related to the step by step navigation
-     # journey, but should not have on page step by step navigation.  They are linked
-     # to by the `pages_related_to_step_nav` link type
-     "related_to_step_navs" => "frontend_links_with_base_path",
+      # These are content items that are related to the step by step navigation
+      # journey, but should not have on page step by step navigation.  They are linked
+      # to by the `pages_related_to_step_nav` link type
+      "related_to_step_navs" => "frontend_links_with_base_path",
 
-     # Taxons that have been created by merging old 'legacy' taxons will have
-     # a reverse link to determine where the replacement Topic Taxonomy taxon
-     # now resides
-     "topic_taxonomy_taxons" => "frontend_links_with_base_path",
+      # Taxons that have been created by merging old 'legacy' taxons will have
+      # a reverse link to determine where the replacement Topic Taxonomy taxon
+      # now resides
+      "topic_taxonomy_taxons" => "frontend_links_with_base_path",
 
-     # Step by steps that a content items may be a part of but is not essential
-     # to completing it.
-     "secondary_to_step_navs" => "frontend_links_with_base_path",
+      # Step by steps that a content items may be a part of but is not essential
+      # to completing it.
+      "secondary_to_step_navs" => "frontend_links_with_base_path",
 
-     # Content items that are linked to with a `role` or `person` link type
-     # will automatically have a `role_appointments` link type with those
-     # items.
-     "role_appointments" => "frontend_links",
+      # Content items that are linked to with a `role` or `person` link type
+      # will automatically have a `role_appointments` link type with those
+      # items.
+      "role_appointments" => "frontend_links",
 
-     # `Role` content items that are ministerial roles will automatically
-     # have a `ministers` link type from the main `ministers` index page.
-     "ministers" => "frontend_links",
-   }.freeze
+      # `Role` content items that are ministerial roles will automatically
+      # have a `ministers` link type from the main `ministers` index page.
+      "ministers" => "frontend_links",
+    }.freeze
 
     def initialize(format)
       @format = format

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -138,7 +138,7 @@ module SchemaGenerator
     end
 
     def publisher_required
-      %w(base_path description details redirects rendering_app routes title)
+      %w[base_path description details redirects rendering_app routes title]
         .select { |property| public_send(property.to_sym).required? }
     end
 
@@ -201,7 +201,7 @@ module SchemaGenerator
     end
 
     class OptionalProperty
-      VALID_STATUSES = %w(required optional forbidden).freeze
+      VALID_STATUSES = %w[required optional forbidden].freeze
 
       def initialize(
         property:,
@@ -269,8 +269,8 @@ module SchemaGenerator
     end
 
     class Links
-      ALLOWED_KEYS = %w(description required minItems maxItems).freeze
-      LINKS_WITHOUT_BASE_PATHS = %w(
+      ALLOWED_KEYS = %w[description required minItems maxItems].freeze
+      LINKS_WITHOUT_BASE_PATHS = %w[
         facets
         facet_groups
         facet_values
@@ -284,7 +284,7 @@ module SchemaGenerator
         ordered_special_representatives
         ordered_traffic_commissioners
         world_locations
-      ).freeze
+      ].freeze
 
       attr_reader :links
 
@@ -295,7 +295,7 @@ module SchemaGenerator
       def guid_properties
         links.each_with_object({}) do |(k, v), hash|
           link = v.merge("$ref" => "#/definitions/guid_list")
-            .delete_if { |key| %w(required).include?(key) }
+            .delete_if { |key| %w[required].include?(key) }
           hash[k] = link
         end
       end
@@ -314,7 +314,7 @@ module SchemaGenerator
           # @FIXME remove need for this check
           definition = LINKS_WITHOUT_BASE_PATHS.include?(k) ? "frontend_links" : "frontend_links_with_base_path"
           link = v.merge("$ref" => "#/definitions/#{definition}")
-            .delete_if { |field| %w(required minItems).include?(field) }
+            .delete_if { |field| %w[required minItems].include?(field) }
           hash[k] = link
         end
       end

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -30,7 +30,7 @@ module SchemaGenerator
       # - publishing_request_id
       # - rendering_app
       # - withdrawn_notice
-      %w(
+      %w[
         base_path
         content_id
         description
@@ -42,7 +42,7 @@ module SchemaGenerator
         schema_name
         title
         updated_at
-      ).sort
+      ].sort
     end
 
     def properties

--- a/lib/schema_generator/notification_schema_generator.rb
+++ b/lib/schema_generator/notification_schema_generator.rb
@@ -29,7 +29,7 @@ module SchemaGenerator
     end
 
     def unpublishing_format?
-      %w(gone redirect vanish).include?(format.schema_name)
+      %w[gone redirect vanish].include?(format.schema_name)
     end
 
     def properties
@@ -58,7 +58,7 @@ module SchemaGenerator
     end
 
     def default_required_properties
-      %w(
+      %w[
         base_path
         content_id
         locale
@@ -66,11 +66,11 @@ module SchemaGenerator
         govuk_request_id
         payload_version
         schema_name
-      )
+      ]
     end
 
     def publishing_required_properties
-      %w(
+      %w[
         analytics_identifier
         description
         details
@@ -89,7 +89,7 @@ module SchemaGenerator
         title
         update_type
         user_journey_document_supertype
-      )
+      ]
     end
 
     def definitions

--- a/lib/schema_generator/publisher_content_schema_generator.rb
+++ b/lib/schema_generator/publisher_content_schema_generator.rb
@@ -21,11 +21,11 @@ module SchemaGenerator
     attr_reader :format, :global_definitions
 
     def required
-      fields = %w(
+      fields = %w[
         document_type
         publishing_app
         schema_name
-      ) + format.publisher_required
+      ] + format.publisher_required
       fields.sort
     end
 

--- a/lib/tasks/regenerate_schemas.rake
+++ b/lib/tasks/regenerate_schemas.rake
@@ -1,6 +1,7 @@
 require "schema_generator/generator"
 require "jsonnet"
 
+desc "Regenerate schemas"
 task :regenerate_schemas do
   print "Generating schemas: "
   FileUtils.rm_rf("dist/formats")

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -7,11 +7,9 @@ end
 def validate_schemas(schema_file_list)
   validation_errors = []
   schema_file_list.each do |schema|
-    begin
-      JSON::Validator.fully_validate(schema, {}, validate_schema: true)
-    rescue JSON::Schema::ValidationError => e
-      validation_errors << "#{schema}: #{e.message}"
-    end
+    JSON::Validator.fully_validate(schema, {}, validate_schema: true)
+  rescue JSON::Schema::ValidationError => e
+    validation_errors << "#{schema}: #{e.message}"
   end
   abort "\nThe following schemas aren't valid:\n" + validation_errors.join("\n") if validation_errors.any?
 end
@@ -82,11 +80,11 @@ task :validate_links, :files do |_, args|
   link_schemas = args[:files] || Rake::FileList.new("formats/*/*/links.json")
   link_schemas.each do |filename|
     schema = JSON.parse(File.read(filename))
-    if schema["required"]
-      warn "\nERROR: #{filename} has required links (#{schema['required'].inspect})"
-      warn "This is disallowed because the publishing-api wouldn't be able to validate partial payloads when sending a PATCH links request."
-      abort
-    end
+    next unless schema["required"]
+
+    warn "\nERROR: #{filename} has required links (#{schema['required'].inspect})"
+    warn "This is disallowed because the publishing-api wouldn't be able to validate partial payloads when sending a PATCH links request."
+    abort
   end
   puts "✔︎"
 end

--- a/spec/lib/schema_generator/schema_spec.rb
+++ b/spec/lib/schema_generator/schema_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe SchemaGenerator::Schema do
       end
 
       let(:expected_ordering) do
-        %w(
+        %w[
           description
           $ref
           type
           required
           properties
           definitions
-        )
+        ]
       end
 
       it "orders the schema" do
@@ -44,7 +44,7 @@ RSpec.describe SchemaGenerator::Schema do
         }
       end
 
-      let(:expected_ordering) { %w(_ a z) }
+      let(:expected_ordering) { %w[_ a z] }
 
       it "orders the property alphabetically" do
         expect(ordered_schema["properties"].keys).to eq expected_ordering
@@ -64,7 +64,7 @@ RSpec.describe SchemaGenerator::Schema do
         }
       end
 
-      let(:expected_ordering) { %w(description type nested) }
+      let(:expected_ordering) { %w[description type nested] }
 
       it "orders the nested object" do
         expect(ordered_schema.keys).to eq expected_ordering

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -7,7 +7,7 @@ shared_context "rake" do
   subject         { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
-    $".reject { |file| file == project_root.join("#{task_path}.rake").to_s }
+    $LOADED_FEATURES.reject { |file| file == project_root.join("#{task_path}.rake").to_s }
   end
 
   before do

--- a/spec/tasks/validate_uniqueness_of_frontend_example_base_paths_spec.rb
+++ b/spec/tasks/validate_uniqueness_of_frontend_example_base_paths_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe "validate" do
     let(:task_name) { "validate_uniqueness_of_frontend_example_base_paths" }
 
     context "all examples have unique base_paths" do
-      let(:examples) {
+      let(:examples) do
         [
           generate_example("a.json", "/letter_a"),
           generate_example("b.json", "/letter_b"),
         ]
-      }
+      end
 
       it "succeeds without exceptions" do
         expect { subject.invoke(examples) }.to_not raise_error
@@ -33,16 +33,16 @@ RSpec.describe "validate" do
     end
 
     context "some examples have duplicate base_paths" do
-      let(:examples) {
+      let(:examples) do
         [
           generate_example("a.json", "/letter_a"),
           generate_example("b.json", "/letter_a"),
         ]
-      }
+      end
 
       it "exits with non-zero exit status and outputs a list of the duplicates" do
-        expect { subject.invoke(examples) }.to raise_error(SystemExit).
-          and output(/a.json.*b.json/m).to_stderr
+        expect { subject.invoke(examples) }.to raise_error(SystemExit)
+          .and output(/a.json.*b.json/m).to_stderr
       end
     end
   end


### PR DESCRIPTION
This PR contains the changes necessary for the app to run on Ruby 2.7.1.

The version of Ruby is left the same, since there is a script that can be run after all the apps have been updated to update the version all at once

- Tested locally with ruby 2.7.1 and 2.6.6

- Deprecation warning from jsonnet gem:
```
/ruby-2.7.1/gems/jsonnet-0.3.0/lib/jsonnet/vm.rb:35: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/ruby-2.7.1/gems/jsonnet-0.3.0/lib/jsonnet/vm.rb:87: warning: The called method `evaluate_file' is defined here
```
This is fixed in master but not the latest version

**Master:**
https://github.com/yugui/ruby-jsonnet/blob/master/lib/jsonnet/vm.rb#L35
https://github.com/yugui/ruby-jsonnet/blob/master/lib/jsonnet/vm.rb#L87
**v0.3.0:**
https://github.com/yugui/ruby-jsonnet/blob/v0.3.0/lib/jsonnet/vm.rb#L35
https://github.com/yugui/ruby-jsonnet/blob/v0.3.0/lib/jsonnet/vm.rb#L87
