### PR TITLE
Add 'ordering' to Take Part pages in schema

### DIFF
--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -312,6 +312,9 @@
         },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "ordering": {
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -414,6 +414,9 @@
         },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "ordering": {
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -184,6 +184,9 @@
         },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "ordering": {
+          "type": "integer"
         }
       }
     },

--- a/formats/take_part.jsonnet
+++ b/formats/take_part.jsonnet
@@ -15,6 +15,9 @@
         image: {
           "$ref": "#/definitions/image",
         },
+        ordering: {
+          type: "integer",
+        },
       },
     },
   },


### PR DESCRIPTION
Depended on by: https://github.com/alphagov/whitehall/pull/5856

Take Part pages save an order in the model in Whitehall so that
they can be displayed in a specific order on the "Get Involved"
page. However this ordering was not being exported to Publishing
API, limiting our ability to migrate away from Whitehall.

Storing the ordering in Publishing API allows us to migrate the
frontend parts away from Whitehall, as this key information would
now be in a centralised place.

Trello: https://trello.com/c/aAW8oqCk/2174-5add-ordering-to-take-part-pages-in-schema