### PR TITLE
Make 'ordering' property a required field in Take Part pages

### DIFF
--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -300,7 +300,8 @@
       "type": "object",
       "required": [
         "body",
-        "image"
+        "image",
+        "ordering"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -402,7 +402,8 @@
       "type": "object",
       "required": [
         "body",
-        "image"
+        "image",
+        "ordering"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -175,7 +175,8 @@
       "type": "object",
       "required": [
         "body",
-        "image"
+        "image",
+        "ordering"
       ],
       "additionalProperties": false,
       "properties": {

--- a/examples/take_part/frontend/take_part.json
+++ b/examples/take_part/frontend/take_part.json
@@ -7,7 +7,8 @@
     "image": {
       "alt_text": "Headshots of 6 councillors",
       "url": "https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/take_part_page/image/21/s300_local_coun_web.jpg"
-    }
+    },
+    "ordering": 1
   },
   "links": {
   },

--- a/formats/take_part.jsonnet
+++ b/formats/take_part.jsonnet
@@ -7,6 +7,7 @@
       required: [
         "body",
         "image",
+        "ordering",
       ],
       properties: {
         body: {


### PR DESCRIPTION
Depends on https://github.com/alphagov/whitehall/pull/5856

It should be safe to make this a required attribute, as it is
enforced on save in Whitehall:
https://github.com/alphagov/whitehall/blob/master/app/models/take_part_page.rb#L7

Trello: https://trello.com/c/aAW8oqCk/2174-5add-ordering-to-take-part-pages-in-schema