### PR TITLE
Mark email alert signup summary as deprecated

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -369,7 +369,7 @@
       }
     },
     "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
+      "description": "DEPRECATED. No longer used.",
       "type": "string"
     },
     "first_published_at": {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -471,7 +471,7 @@
       }
     },
     "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
+      "description": "DEPRECATED. No longer used.",
       "type": "string"
     },
     "first_published_at": {

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -241,7 +241,7 @@
       }
     },
     "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
+      "description": "DEPRECATED. No longer used.",
       "type": "string"
     },
     "first_published_at": {

--- a/formats/shared/definitions/email_alert.jsonnet
+++ b/formats/shared/definitions/email_alert.jsonnet
@@ -21,7 +21,7 @@
     },
   },
   email_alert_signup_summary: {
-    description: "TODO: Use top-level description instead",
+    description: "DEPRECATED. No longer used.",
     type: "string",
   },
   tags: {


### PR DESCRIPTION
https://trello.com/c/mk5M2aKD/619-general-design-and-stylistic-updates-to-signup-workflow

This is no longer used since [1]. We aim to delete this schema
entirely, by migrating its last remaining use (travel advice),
to use the generic content item signup functionality [2]. It's
therefore not worth pursuing the deletion of this specific field.

[1]: https://github.com/alphagov/email-alert-frontend/pull/918/files#diff-dcf8762f5933e092b429cc90d620101f6cad49658d9e65c1385ddb8c04bc0427L42
[2]: https://github.com/alphagov/email-alert-frontend/blob/0e1608e120ed32665c5aaabc224a226657783047/README.md#signup