### PR TITLE
Add brexit_current_state_notice

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -279,6 +279,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -351,6 +371,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -395,6 +395,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -467,6 +487,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -161,6 +161,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -233,6 +253,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -279,6 +279,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -356,6 +376,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -394,6 +394,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -471,6 +491,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -197,6 +197,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -274,6 +294,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -281,6 +281,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -342,6 +362,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -399,6 +399,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -460,6 +480,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -193,6 +193,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -254,6 +274,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -262,6 +262,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -324,6 +344,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -361,6 +361,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -423,6 +443,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -176,6 +176,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -217,6 +237,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -313,6 +313,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -382,6 +402,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -436,6 +436,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -505,6 +525,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -231,6 +231,26 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "brexit_current_state_notice": {
+      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -300,6 +320,9 @@
         },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "brexit_current_state_notice": {
+          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/examples/case_study/frontend/case_study.json
+++ b/examples/case_study/frontend/case_study.json
@@ -37,6 +37,16 @@
     "format_display_type": "case_study",
     "emphasised_organisations": [
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
+    ],
+    "brexit_current_state_notice": [
+      {
+        "title": "test page",
+        "href": "https://www.gov.uk/transition"
+      },
+      {
+        "title": "test page2",
+        "href": "https://www.gov.uk/coronavirus"
+      }
     ]
   },
   "links": {

--- a/examples/detailed_guide/frontend/detailed_guide.json
+++ b/examples/detailed_guide/frontend/detailed_guide.json
@@ -45,6 +45,16 @@
     "emphasised_organisations": [
       "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
     ],
+    "brexit_current_state_notice": [
+      {
+        "title": "test page",
+        "href": "https://www.gov.uk/transition"
+      },
+      {
+        "title": "test page2",
+        "href": "https://www.gov.uk/coronavirus"
+      }
+    ],
     "political": false
   },
   "links": {

--- a/examples/document_collection/frontend/document_collection.json
+++ b/examples/document_collection/frontend/document_collection.json
@@ -79,6 +79,16 @@
     "political": false,
     "emphasised_organisations": [
       "d39237a5-678b-4bb5-a372-eb2cb036933d"
+    ],
+    "brexit_current_state_notice": [
+      {
+        "title": "test page",
+        "href": "https://www.gov.uk/transition"
+      },
+      {
+        "title": "test page2",
+        "href": "https://www.gov.uk/coronavirus"
+      }
     ]
   },
   "links": {

--- a/examples/publication/frontend/publication.json
+++ b/examples/publication/frontend/publication.json
@@ -33,6 +33,16 @@
     "political": false,
     "emphasised_organisations": [
       "16628142-57b2-4611-bc03-5912785acee3"
+    ],
+    "brexit_current_state_notice": [
+      {
+        "title": "test page",
+        "href": "https://www.gov.uk/transition"
+      },
+      {
+        "title": "test page2",
+        "href": "https://www.gov.uk/coronavirus"
+      }
     ]
   },
   "links": {

--- a/formats/case_study.jsonnet
+++ b/formats/case_study.jsonnet
@@ -46,6 +46,9 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
+        },
+        brexit_current_state_notice: {
+          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -64,6 +64,9 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
+        },
+        brexit_current_state_notice: {
+          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/document_collection.jsonnet
+++ b/formats/document_collection.jsonnet
@@ -60,6 +60,9 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
+        },
+        brexit_current_state_notice: {
+          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/html_publication.jsonnet
+++ b/formats/html_publication.jsonnet
@@ -30,6 +30,9 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
+        },
+        brexit_current_state_notice: {
+          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -75,6 +75,9 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
+        },
+        brexit_current_state_notice: {
+          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -298,5 +298,25 @@
       },
     },
     description: "A list of URLs and titles for a brexit no deal notice.",
+  },
+  brexit_current_state_notice: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+      },
+    },
+    description: "A list of URLs and titles about the current state of guidance that might change after brexit.",
   }
 }


### PR DESCRIPTION
## What

Add a new field to the schema of:
- CaseStudy
- DetailedGuide
- DocumentCollection
- Publication
- HTML publication

## Context

- We are adding a button to Whitehall to allow publishers to display a new type of call out box on their transition related content. Here's the [PR](https://github.com/alphagov/whitehall/pull/5894) .
- Currently publishers can add a call out box for post transition content, this is called the `brexit_no_deal_notice` and is present on docs such as [this](https://www.gov.uk/api/content/guidance/driving-in-the-eu-from-1-january-2021). 
- A document will only ever have either a `brexit_no_deal_notice` or a `brexit_current_state_notice`. This is determined by a validation on the Whitehall database. 

---
https://trello.com/c/IwXzb5FM/589-design-whitehall-publisher-functionality-to-generate-current-state-notice
