### PR TITLE
Add body to step by steps

### DIFF
--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -211,6 +211,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "body_html_and_govspeak": {
       "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
       "anyOf": [
@@ -257,6 +261,9 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -263,6 +263,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "body_html_and_govspeak": {
       "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
       "anyOf": [
@@ -309,6 +313,9 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -169,6 +169,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "body_html_and_govspeak": {
       "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
       "anyOf": [
@@ -194,6 +198,9 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
         "step_by_step_nav": {
           "$ref": "#/definitions/step_by_step_nav"
         }

--- a/formats/step_by_step_nav.jsonnet
+++ b/formats/step_by_step_nav.jsonnet
@@ -18,7 +18,10 @@
       properties: {
         step_by_step_nav: {
           "$ref": "#/definitions/step_by_step_nav"
-        }
+        },
+        body: {
+          "$ref": "#/definitions/body",
+        },
       }
     }
   }


### PR DESCRIPTION
Site search can only ingest the title and description of a step by step at present. 

The body of a step by step is written in markdown-ish, which we can convert to html using kramdown or similar. By adding this html to the body field of the content item, we'll be able to search for them much more easily.