### PR TITLE
Further protected food changes

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2550,7 +2550,6 @@
             "wines",
             "aromatised-wines",
             "traditional-terms-for-wine",
-            "names-protected-by-international-treaty",
             "american-viticultural-areas"
           ]
         },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2441,6 +2441,7 @@
               "brazil",
               "bulgaria",
               "cambodia",
+              "canada",
               "chile",
               "china",
               "colombia",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2580,6 +2580,7 @@
               "brazil",
               "bulgaria",
               "cambodia",
+              "canada",
               "chile",
               "china",
               "colombia",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2689,7 +2689,6 @@
             "wines",
             "aromatised-wines",
             "traditional-terms-for-wine",
-            "names-protected-by-international-treaty",
             "american-viticultural-areas"
           ]
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2352,7 +2352,6 @@
             "wines",
             "aromatised-wines",
             "traditional-terms-for-wine",
-            "names-protected-by-international-treaty",
             "american-viticultural-areas"
           ]
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2243,6 +2243,7 @@
               "brazil",
               "bulgaria",
               "cambodia",
+              "canada",
               "chile",
               "china",
               "colombia",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -2047,7 +2047,6 @@
           "wines",
           "aromatised-wines",
           "traditional-terms-for-wine",
-          "names-protected-by-international-treaty",
           "american-viticultural-areas",
         ]
       },

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -2195,6 +2195,7 @@
             "brazil",
             "bulgaria",
             "cambodia",
+            "canada",
             "chile",
             "china",
             "colombia",


### PR DESCRIPTION
Adds further changes to the protected food names:

- Adds Canada to the country of origin options
- Removes Name protected by international treaty from the register field

Trello card: https://trello.com/c/F3HaBQBp/2258-2-further-changes-to-protected-food-drink-names-finder