### PR TITLE
Add air-quality as a land_use

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -764,6 +764,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "air-quality",
               "arable-land",
               "boundaries",
               "coast",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -867,6 +867,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "air-quality",
               "arable-land",
               "boundaries",
               "coast",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -673,6 +673,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "air-quality",
               "arable-land",
               "boundaries",
               "coast",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1024,6 +1024,7 @@
         items: {
           type: "string",
           enum: [
+            "air-quality",
             "arable-land",
             "boundaries",
             "coast",


### PR DESCRIPTION
This is available as an option in specialist-publisher but it's missing from govuk-content-schemas: https://github.com/alphagov/specialist-publisher/blob/4000e6dec54bafd1b8af4516c3eed1abbb874a50/lib/documents/schemas/countryside_stewardship_grants.json#L43

This means that users can't create documents with that option. See https://govuk.zendesk.com/agent/tickets/4431297 for more details.