### PR TITLE
Revert "Add brexit_current_state_notice"

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -279,26 +279,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -371,9 +351,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -395,26 +395,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -487,9 +467,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -161,26 +161,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -253,9 +233,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -279,26 +279,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -376,9 +356,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -394,26 +394,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -491,9 +471,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -197,26 +197,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -294,9 +274,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -281,26 +281,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -362,9 +342,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -399,26 +399,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -480,9 +460,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -193,26 +193,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -274,9 +254,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -262,26 +262,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -344,9 +324,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -361,26 +361,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -443,9 +423,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -176,26 +176,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -237,9 +217,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -313,26 +313,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -402,9 +382,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -436,26 +436,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -525,9 +505,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -231,26 +231,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_current_state_notice": {
-      "description": "A list of URLs and titles about the current state of guidance that might change after brexit.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "brexit_no_deal_notice": {
       "description": "A list of URLs and titles for a brexit no deal notice.",
       "type": "array",
@@ -320,9 +300,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_current_state_notice": {
-          "$ref": "#/definitions/brexit_current_state_notice"
         },
         "brexit_no_deal_notice": {
           "$ref": "#/definitions/brexit_no_deal_notice"

--- a/examples/case_study/frontend/case_study.json
+++ b/examples/case_study/frontend/case_study.json
@@ -37,16 +37,6 @@
     "format_display_type": "case_study",
     "emphasised_organisations": [
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
-    ],
-    "brexit_current_state_notice": [
-      {
-        "title": "test page",
-        "href": "https://www.gov.uk/transition"
-      },
-      {
-        "title": "test page2",
-        "href": "https://www.gov.uk/coronavirus"
-      }
     ]
   },
   "links": {

--- a/examples/detailed_guide/frontend/detailed_guide.json
+++ b/examples/detailed_guide/frontend/detailed_guide.json
@@ -45,16 +45,6 @@
     "emphasised_organisations": [
       "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
     ],
-    "brexit_current_state_notice": [
-      {
-        "title": "test page",
-        "href": "https://www.gov.uk/transition"
-      },
-      {
-        "title": "test page2",
-        "href": "https://www.gov.uk/coronavirus"
-      }
-    ],
     "political": false
   },
   "links": {

--- a/examples/document_collection/frontend/document_collection.json
+++ b/examples/document_collection/frontend/document_collection.json
@@ -79,16 +79,6 @@
     "political": false,
     "emphasised_organisations": [
       "d39237a5-678b-4bb5-a372-eb2cb036933d"
-    ],
-    "brexit_current_state_notice": [
-      {
-        "title": "test page",
-        "href": "https://www.gov.uk/transition"
-      },
-      {
-        "title": "test page2",
-        "href": "https://www.gov.uk/coronavirus"
-      }
     ]
   },
   "links": {

--- a/examples/publication/frontend/publication.json
+++ b/examples/publication/frontend/publication.json
@@ -33,16 +33,6 @@
     "political": false,
     "emphasised_organisations": [
       "16628142-57b2-4611-bc03-5912785acee3"
-    ],
-    "brexit_current_state_notice": [
-      {
-        "title": "test page",
-        "href": "https://www.gov.uk/transition"
-      },
-      {
-        "title": "test page2",
-        "href": "https://www.gov.uk/coronavirus"
-      }
     ]
   },
   "links": {

--- a/formats/case_study.jsonnet
+++ b/formats/case_study.jsonnet
@@ -46,9 +46,6 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
-        },
-        brexit_current_state_notice: {
-          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -64,9 +64,6 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
-        },
-        brexit_current_state_notice: {
-          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/document_collection.jsonnet
+++ b/formats/document_collection.jsonnet
@@ -60,9 +60,6 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
-        },
-        brexit_current_state_notice: {
-          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/html_publication.jsonnet
+++ b/formats/html_publication.jsonnet
@@ -30,9 +30,6 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
-        },
-        brexit_current_state_notice: {
-          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -75,9 +75,6 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
-        },
-        brexit_current_state_notice: {
-          "$ref": "#/definitions/brexit_current_state_notice",
         }
       },
     },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -298,25 +298,5 @@
       },
     },
     description: "A list of URLs and titles for a brexit no deal notice.",
-  },
-  brexit_current_state_notice: {
-    type: "array",
-    items: {
-      type: "object",
-      additionalProperties: false,
-      required: [
-        "title",
-        "href",
-      ],
-      properties: {
-        title: {
-          type: "string",
-        },
-        href: {
-          type: "string",
-        },
-      },
-    },
-    description: "A list of URLs and titles about the current state of guidance that might change after brexit.",
   }
 }


### PR DESCRIPTION
Reverts alphagov/govuk-content-schemas#1027

We are no longer adding the current state notice to any document types. The [Whitehall PR ](https://github.com/alphagov/whitehall/pull/5894) has been closed, so we should revert this PR. 