### PR TITLE
Add visually_expanded attribute to manual_sections

### DIFF
--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -328,6 +328,10 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "visually_expanded": {
+          "description": "A flag set by a content designer when they want the manual sections to be expanded and display without accordions.",
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -435,6 +435,10 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "visually_expanded": {
+          "description": "A flag set by a content designer when they want the manual sections to be expanded and display without accordions.",
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -199,6 +199,10 @@
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
+        },
+        "visually_expanded": {
+          "description": "A flag set by a content designer when they want the manual sections to be expanded and display without accordions.",
+          "type": "boolean"
         }
       }
     },

--- a/examples/manual_section/frontend/what-is-content-design.json
+++ b/examples/manual_section/frontend/what-is-content-design.json
@@ -33,7 +33,8 @@
         "abbreviation": "GDS",
         "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
       }
-    ]
+    ],
+    "visually_expanded": false
   },
   "links": {
     "available_translations": [

--- a/examples/manual_section/publisher_v2/manual_section.json
+++ b/examples/manual_section/publisher_v2/manual_section.json
@@ -42,7 +42,8 @@
         "abbreviation": "GDS",
         "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
       }
-    ]
+    ],
+    "visually_expanded": false
   },
   "routes": [
     {

--- a/formats/manual_section.jsonnet
+++ b/formats/manual_section.jsonnet
@@ -26,6 +26,10 @@
         organisations: {
           "$ref": "#/definitions/manual_organisations",
         },
+        visually_expanded: {
+          type: "boolean",
+          description: "A flag set by a content designer when they want the manual sections to be expanded and display without accordions.",
+        },
       },
     },
   },


### PR DESCRIPTION
A `visually_expanded` attribute has been added to manual_sections published by Manuals-Publisher.
[trello](https://trello.com/c/wgEKW9Ze/2398-5-allow-manuals-publisher-to-set-accordions-to-open)