### PR TITLE
Deprecate supertypes that aren't used downstream

### DIFF
--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/external_content/notification/schema.json
+++ b/dist/formats/external_content/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/facet_group/notification/schema.json
+++ b/dist/formats/facet_group/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/get_involved/notification/schema.json
+++ b/dist/formats/get_involved/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/government/notification/schema.json
+++ b/dist/formats/government/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/history/notification/schema.json
+++ b/dist/formats/history/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/ministers_index/notification/schema.json
+++ b/dist/formats/ministers_index/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/smart_answer/notification/schema.json
+++ b/dist/formats/smart_answer/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -15,7 +15,6 @@
     "govuk_request_id",
     "links",
     "locale",
-    "navigation_document_supertype",
     "payload_version",
     "phase",
     "public_updated_at",
@@ -25,8 +24,7 @@
     "routes",
     "schema_name",
     "title",
-    "update_type",
-    "user_journey_document_supertype"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {

--- a/lib/schema_generator/notification_schema_generator.rb
+++ b/lib/schema_generator/notification_schema_generator.rb
@@ -79,7 +79,6 @@ module SchemaGenerator
         first_published_at
         government_document_supertype
         links
-        navigation_document_supertype
         phase
         public_updated_at
         publishing_app
@@ -88,7 +87,6 @@ module SchemaGenerator
         routes
         title
         update_type
-        user_journey_document_supertype
       ]
     end
 


### PR DESCRIPTION
These supertypes used to be consumed by downstream apps (eg search-api and content-data). We've done some work to remove this dependency, so that the only app still left relying on finding supertypes via a notification is email-alert-api.

Our strategy is that supergroups are a point in time feature of a document based on its type. We should therefore devolve working these out to apps that wish to use them, and minimise the complexity of everything else.

- [Content-data-api not longer looks for them](alphagov/content-data-api@48a5c97#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3)
- [Search-api works them out for itself](https://github.com/alphagov/search-api/blob/987fa2313c0b35528eb87b892dccbd1cfd692dca/lib/indexer/document_preparer.rb#L155)
- [Publishing-api still sends them, but we don't want it to](https://github.com/alphagov/publishing-api/blob/a6ec79b0a8d77b991e0dd192f89dd88f9fe0b687/app/presenters/edition_presenter.rb#L52)

Email alert api still uses government_document_supertype and email_document_supertype so we'll leave them for another day.

https://trello.com/c/hp5BJD2i/117-unused-incorrect-supertypes-in-content-items