### PR TITLE
Update references to default branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,8 +53,8 @@ node {
       env.GIT_COMMIT_HASH = govuk.getFullCommitHash()
     }
 
-    stage("Merge master") {
-      govuk.mergeMasterBranch();
+    stage("Merge main") {
+      govuk.mergeIntoBranch("main");
     }
 
     stage("bundle install") {
@@ -80,7 +80,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'master') {
+    if (env.BRANCH_NAME == 'main') {
       stage("Push release tag") {
         govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
       }

--- a/docs/running-frontend-against-examples.md
+++ b/docs/running-frontend-against-examples.md
@@ -8,7 +8,7 @@ Note: The dummy content store also has an index page which lists all the example
 
 ## Using the Heroku version
 
-There is an instance of the dummy content store running on Heroku, which applications can use rather than running it locally. Whenever master changes, it will automatically be updated, and the available examples may change.
+There is an instance of the dummy content store running on Heroku, which applications can use rather than running it locally. Whenever main changes, it will automatically be updated, and the available examples may change.
 
 [govuk-content-store-examples.herokuapp.com](https://govuk-content-store-examples.herokuapp.com/)
 

--- a/docs/why-contract-testing.md
+++ b/docs/why-contract-testing.md
@@ -35,7 +35,7 @@ This comprises three things:
 
 1. json-schema files which define the *publishing representation* for a given format
 2. a curated set of frontend examples of that format, which are validated against the schemas
-3. [a mechanism to convert from the 'publisher' schemas to the 'frontend' schemas](https://github.com/alphagov/govuk-content-schemas/blob/master/lib/govuk_content_schemas/frontend_schema_generator.rb), simulating the behaviour of the content store
+3. [a mechanism to convert from the 'publisher' schemas to the 'frontend' schemas](https://github.com/alphagov/govuk-content-schemas/blob/main/lib/govuk_content_schemas/frontend_schema_generator.rb), simulating the behaviour of the content store
 
 With those three parts we are able to verify the examples against the schemas.
 


### PR DESCRIPTION
The branch has been renamed from `master` to `main` for this repo, so we'll need to update the references to it.