### PR TITLE
Specify defaultBranch when calling pushTag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ node {
 
     if (env.BRANCH_NAME == 'main') {
       stage("Push release tag") {
-        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, 'main')
       }
 
       govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, 'deploy')


### PR DESCRIPTION
The [`pushTag` method](https://github.com/alphagov/govuk-jenkinslib/blob/7d9befbef4b81e889fb7fb9f4562ec9afd730f30/vars/govuk.groovy#L700) accepts an argument for the default branch, which we need to change to be `main` rather than the default of `master`, otherwise the tag doesn't actually get pushed.