### PR TITLE
Add override url field to Taxon schema

### DIFF
--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -322,6 +322,9 @@
           "description": "Usage notes for editors when tagging content to a taxon.",
           "type": "string"
         },
+        "url_override": {
+          "$ref": "#/definitions/taxonomy_url_override"
+        },
         "visible_to_departmental_editors": {
           "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
           "type": "boolean"
@@ -634,6 +637,10 @@
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",
+      "type": "string"
+    },
+    "taxonomy_url_override": {
+      "description": "Set a custom url for the taxon to override the default of /taxon",
       "type": "string"
     },
     "title": {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -438,6 +438,9 @@
           "description": "Usage notes for editors when tagging content to a taxon.",
           "type": "string"
         },
+        "url_override": {
+          "$ref": "#/definitions/taxonomy_url_override"
+        },
         "visible_to_departmental_editors": {
           "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
           "type": "boolean"
@@ -784,6 +787,10 @@
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",
+      "type": "string"
+    },
+    "taxonomy_url_override": {
+      "description": "Set a custom url for the taxon to override the default of /taxon",
       "type": "string"
     },
     "title": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -186,6 +186,9 @@
           "description": "Usage notes for editors when tagging content to a taxon.",
           "type": "string"
         },
+        "url_override": {
+          "$ref": "#/definitions/taxonomy_url_override"
+        },
         "visible_to_departmental_editors": {
           "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
           "type": "boolean"
@@ -378,6 +381,10 @@
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",
+      "type": "string"
+    },
+    "taxonomy_url_override": {
+      "description": "Set a custom url for the taxon to override the default of /taxon",
       "type": "string"
     },
     "title": {

--- a/formats/shared/definitions/taxonomy.jsonnet
+++ b/formats/shared/definitions/taxonomy.jsonnet
@@ -3,4 +3,8 @@
     type: "string",
     description: "An internal name for taxonomy admin interfaces. Includes parent.",
   },
+  taxonomy_url_override: {
+    type: "string",
+    description: "Set a custom url for the taxon to override the default of /taxon",
+  },
 }

--- a/formats/taxon.jsonnet
+++ b/formats/taxon.jsonnet
@@ -16,6 +16,9 @@
           type: "boolean",
           description: "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
         },
+        url_override: {
+          "$ref": "#/definitions/taxonomy_url_override",
+        },
       },
     },
   },


### PR DESCRIPTION
## What

We'd like to be able to customise the url of a taxon via an attribute stored in its content item. This will make it easier to curate the taxon's breadcrumbs as well as the taxon page's url. 

[Trello](https://trello.com/c/V2nmHHA6/1516-add-overrideurl-to-taxons)
[Related](https://github.com/alphagov/content-tagger/pull/1204)