### PR TITLE
Remove Brexit callout fields

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -279,26 +279,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -351,9 +331,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -393,26 +393,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -465,9 +445,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -161,26 +161,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -233,9 +213,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -279,26 +279,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -356,9 +336,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -392,26 +392,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -469,9 +449,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -197,26 +197,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -274,9 +254,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -281,26 +281,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -342,9 +322,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -397,26 +397,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -458,9 +438,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -193,26 +193,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -254,9 +234,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -262,26 +262,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -324,9 +304,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -359,26 +359,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -421,9 +401,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -176,26 +176,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "description_optional": {
       "anyOf": [
         {
@@ -217,9 +197,6 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "first_published_version": {
           "type": "boolean"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -314,26 +314,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -383,9 +363,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -435,26 +435,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -504,9 +484,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -232,26 +232,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "brexit_no_deal_notice": {
-      "description": "A list of URLs and titles for a brexit no deal notice.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -301,9 +281,6 @@
         },
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "brexit_no_deal_notice": {
-          "$ref": "#/definitions/brexit_no_deal_notice"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"

--- a/formats/case_study.jsonnet
+++ b/formats/case_study.jsonnet
@@ -43,9 +43,6 @@
         },
         emphasised_organisations: {
           "$ref": "#/definitions/emphasised_organisations",
-        },
-        brexit_no_deal_notice: {
-          "$ref": "#/definitions/brexit_no_deal_notice",
         }
       },
     },

--- a/formats/detailed_guide.jsonnet
+++ b/formats/detailed_guide.jsonnet
@@ -61,9 +61,6 @@
         },
         national_applicability: {
           "$ref": "#/definitions/national_applicability",
-        },
-        brexit_no_deal_notice: {
-          "$ref": "#/definitions/brexit_no_deal_notice",
         }
       },
     },

--- a/formats/document_collection.jsonnet
+++ b/formats/document_collection.jsonnet
@@ -57,9 +57,6 @@
         },
         emphasised_organisations: {
           "$ref": "#/definitions/emphasised_organisations",
-        },
-        brexit_no_deal_notice: {
-          "$ref": "#/definitions/brexit_no_deal_notice",
         }
       },
     },

--- a/formats/html_publication.jsonnet
+++ b/formats/html_publication.jsonnet
@@ -27,9 +27,6 @@
         isbn: {
           type: "string",
           description: "Identifies the Print ISBN to be displayed when printing an HTML Publication",
-        },
-        brexit_no_deal_notice: {
-          "$ref": "#/definitions/brexit_no_deal_notice",
         }
       },
     },

--- a/formats/publication.jsonnet
+++ b/formats/publication.jsonnet
@@ -73,9 +73,6 @@
         },
         national_applicability: {
           "$ref": "#/definitions/national_applicability",
-        },
-        brexit_no_deal_notice: {
-          "$ref": "#/definitions/brexit_no_deal_notice",
         }
       },
     },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -278,25 +278,5 @@
     description: "DEPRECATED. The date the content was first published. Used in details. Deprecated in favour of top level `first_published_at`.",
     type: "string",
     format: "date-time",
-  },
-  brexit_no_deal_notice: {
-    type: "array",
-    items: {
-      type: "object",
-      additionalProperties: false,
-      required: [
-        "title",
-        "href",
-      ],
-      properties: {
-        title: {
-          type: "string",
-        },
-        href: {
-          type: "string",
-        },
-      },
-    },
-    description: "A list of URLs and titles for a brexit no deal notice.",
   }
 }


### PR DESCRIPTION
We're retiring this section, as all content should now be up to date and
therefore no longer needs a clarification block.

We'll deploy this after the changes to the publishing app.

https://trello.com/c/xnVMpmH8/1526-actually-remove-brexit-callout-for-24-may
