### PR TITLE
Update specialist doc type

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -3368,6 +3368,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "uk_market_conformity_assessment_body_address": {
+          "type": "string"
+        },
         "uk_market_conformity_assessment_body_email": {
           "type": "string"
         },
@@ -3403,6 +3406,9 @@
           }
         },
         "uk_market_conformity_assessment_body_name": {
+          "type": "string"
+        },
+        "uk_market_conformity_assessment_body_notified_body_number": {
           "type": "string"
         },
         "uk_market_conformity_assessment_body_number": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -3522,6 +3522,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "uk_market_conformity_assessment_body_address": {
+          "type": "string"
+        },
         "uk_market_conformity_assessment_body_email": {
           "type": "string"
         },
@@ -3557,6 +3560,9 @@
           }
         },
         "uk_market_conformity_assessment_body_name": {
+          "type": "string"
+        },
+        "uk_market_conformity_assessment_body_notified_body_number": {
           "type": "string"
         },
         "uk_market_conformity_assessment_body_number": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -3176,6 +3176,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "uk_market_conformity_assessment_body_address": {
+          "type": "string"
+        },
         "uk_market_conformity_assessment_body_email": {
           "type": "string"
         },
@@ -3211,6 +3214,9 @@
           }
         },
         "uk_market_conformity_assessment_body_name": {
+          "type": "string"
+        },
+        "uk_market_conformity_assessment_body_notified_body_number": {
           "type": "string"
         },
         "uk_market_conformity_assessment_body_number": {

--- a/examples/specialist_document/frontend/uk-market-conformity-assessment-body.json
+++ b/examples/specialist_document/frontend/uk-market-conformity-assessment-body.json
@@ -10,6 +10,7 @@
       "uk_market_conformity_assessment_body_name": "rail system confomity body example",
       "updated_at": "2015-02-13T13:45:00.000+00:00",
       "uk_market_conformity_assessment_body_number": "0001",
+      "uk_market_conformity_assessment_body_notified_body_number": "0002",
       "uk_market_conformity_assessment_body_registered_office_location": "united-kingdom",
       "uk_market_conformity_assessment_body_testing_locations": [
         "north-macedonia",
@@ -18,6 +19,7 @@
       "uk_market_conformity_assessment_body_website": "somewebsite.somewhere.com",
       "uk_market_conformity_assessment_body_email": "contactthem@somewhere.com",
       "uk_market_conformity_assessment_body_phone": "01555555555",
+      "uk_market_conformity_assessment_body_address": "1 GDS Way, London",
       "uk_market_conformity_assessment_body_legislative_area": [
         "railway-interoperability"
       ]

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -452,6 +452,9 @@
       uk_market_conformity_assessment_body_number: {
         type: "string",
       },
+      uk_market_conformity_assessment_body_notified_body_number: {
+        type: "string",
+      },
       uk_market_conformity_assessment_body_type: {
         type: "array",
         items: {
@@ -689,6 +692,9 @@
         type: "string",
       },
       uk_market_conformity_assessment_body_phone: {
+        type: "string",
+      },
+      uk_market_conformity_assessment_body_address: {
         type: "string",
       },
       uk_market_conformity_assessment_body_legislative_area: {


### PR DESCRIPTION
## What

Extending specialist document content schemas following request to add more fields to `uk-conformity-assessment-bodies`

Ref: https://github.com/alphagov/specialist-publisher/pull/1899

Trello: https://trello.com/c/DvVWCPT7/2644-changes-to-ukmcab-specialist-document-and-finder-5