### PR TITLE
Add TakePart pages to linkable contents

### DIFF
--- a/dist/formats/get_involved/frontend/schema.json
+++ b/dist/formats/get_involved/frontend/schema.json
@@ -261,6 +261,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -304,6 +308,42 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "take_part_pages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "description",
+              "details"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "body",
+                  "image"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "$ref": "#/definitions/body"
+                  },
+                  "image": {
+                    "$ref": "#/definitions/image"
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
@@ -448,6 +488,48 @@
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",

--- a/dist/formats/get_involved/notification/schema.json
+++ b/dist/formats/get_involved/notification/schema.json
@@ -361,6 +361,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -404,6 +408,42 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "take_part_pages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "description",
+              "details"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "body",
+                  "image"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "$ref": "#/definitions/body"
+                  },
+                  "image": {
+                    "$ref": "#/definitions/image"
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
@@ -561,6 +601,48 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",

--- a/dist/formats/get_involved/publisher_v2/schema.json
+++ b/dist/formats/get_involved/publisher_v2/schema.json
@@ -157,6 +157,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "description_optional": {
       "anyOf": [
         {
@@ -176,6 +180,42 @@
       "properties": {
         "body": {
           "type": "string"
+        },
+        "take_part_pages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "description",
+              "details"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "body",
+                  "image"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "$ref": "#/definitions/body"
+                  },
+                  "image": {
+                    "$ref": "#/definitions/image"
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
@@ -194,6 +234,48 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",

--- a/formats/get_involved.jsonnet
+++ b/formats/get_involved.jsonnet
@@ -1,13 +1,49 @@
 (import "shared/default_format.jsonnet") + {
   document_type: "get_involved",
 
-  definitions: {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
     details: {
       type: "object",
       additionalProperties: false,
       required: ["body"],
       properties: {
         body: { type: "string" },
+        take_part_pages: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "title",
+              "description",
+              "details",
+            ],
+            properties: {
+              title: {
+                type: "string",
+              },
+              description: {
+                type: "string",
+              },
+              details: {
+                type: "object",
+                additionalProperties: false,
+                required: [
+                  "body",
+                  "image",
+                ],
+                properties: {
+                  body: {
+                    "$ref": "#/definitions/body",
+                  },
+                  image: {
+                    "$ref": "#/definitions/image",
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
This PR allows us to patch-link Take Part pages to the Get Involved page
with intent of showing the needed data once the latter is moved to the
Government Frontend repo.

Trello: https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend