### PR TITLE
Add topical_events links to travel advice pages

### DIFF
--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -164,6 +164,9 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -182,6 +182,9 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -265,6 +268,9 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
         "topics": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -75,6 +75,9 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"

--- a/formats/travel_advice.jsonnet
+++ b/formats/travel_advice.jsonnet
@@ -83,5 +83,6 @@
   },
   links: (import "shared/base_links.jsonnet") + {
     related: "",
+    topical_events: "",
   },
 }


### PR DESCRIPTION
We want updates to the Afghanistan travel advice page to generate emails to people who sign up for the [topical event](https://www.gov.uk/government/topical-events/afghanistan-uk-government-response)

We are therefore adding the topical_events links to the travel_advice schema, which will allow us to tag the page appropriately.