### PR TITLE
Add OIM Projects to specialist document type content schema

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -133,6 +133,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -157,6 +157,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -143,6 +143,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -133,6 +133,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -157,6 +157,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -143,6 +143,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -133,6 +133,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -157,6 +157,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -143,6 +143,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -136,6 +136,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -160,6 +160,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -143,6 +143,7 @@
         "official",
         "official_statistics",
         "official_statistics_announcement",
+        "oim_project",
         "open_consultation",
         "oral_statement",
         "organisation",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -51,6 +51,7 @@
         "maib_report",
         "marine_notice",
         "medical_safety_alert",
+        "oim_project",
         "protected_food_drink_name",
         "raib_report",
         "research_for_development_output",
@@ -388,6 +389,9 @@
         },
         {
           "$ref": "#/definitions/medical_safety_alert_metadata"
+        },
+        {
+          "$ref": "#/definitions/oim_project_metadata"
         },
         {
           "$ref": "#/definitions/protected_food_drink_name_metadata"
@@ -2334,6 +2338,41 @@
         }
       },
       "minItems": 1
+    },
+    "oim_project_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "oim_project_closed_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "oim_project_opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "oim_project_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "oim_project_type": {
+          "type": "string",
+          "enum": [
+            "annual-report",
+            "five-yearly-report",
+            "discretionary-report",
+            "report-on-proposed-regulatory-provision",
+            "report-after-regulatory-provision-is-passed-or-made",
+            "report-on-provision-considered-to-have-detrimental-effects"
+          ]
+        }
+      }
     },
     "protected_food_drink_name_metadata": {
       "type": "object",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -75,6 +75,7 @@
         "maib_report",
         "marine_notice",
         "medical_safety_alert",
+        "oim_project",
         "protected_food_drink_name",
         "raib_report",
         "research_for_development_output",
@@ -489,6 +490,9 @@
         },
         {
           "$ref": "#/definitions/medical_safety_alert_metadata"
+        },
+        {
+          "$ref": "#/definitions/oim_project_metadata"
         },
         {
           "$ref": "#/definitions/protected_food_drink_name_metadata"
@@ -2467,6 +2471,41 @@
         }
       },
       "minItems": 1
+    },
+    "oim_project_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "oim_project_closed_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "oim_project_opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "oim_project_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "oim_project_type": {
+          "type": "string",
+          "enum": [
+            "annual-report",
+            "five-yearly-report",
+            "discretionary-report",
+            "report-on-proposed-regulatory-provision",
+            "report-after-regulatory-provision-is-passed-or-made",
+            "report-on-provision-considered-to-have-detrimental-effects"
+          ]
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -61,6 +61,7 @@
         "maib_report",
         "marine_notice",
         "medical_safety_alert",
+        "oim_project",
         "protected_food_drink_name",
         "raib_report",
         "research_for_development_output",
@@ -297,6 +298,9 @@
         },
         {
           "$ref": "#/definitions/medical_safety_alert_metadata"
+        },
+        {
+          "$ref": "#/definitions/oim_project_metadata"
         },
         {
           "$ref": "#/definitions/protected_food_drink_name_metadata"
@@ -2136,6 +2140,41 @@
         }
       },
       "minItems": 1
+    },
+    "oim_project_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "oim_project_closed_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "oim_project_opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "oim_project_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "oim_project_type": {
+          "type": "string",
+          "enum": [
+            "annual-report",
+            "five-yearly-report",
+            "discretionary-report",
+            "report-on-proposed-regulatory-provision",
+            "report-after-regulatory-provision-is-passed-or-made",
+            "report-on-provision-considered-to-have-detrimental-effects"
+          ]
+        }
+      }
     },
     "protected_food_drink_name_metadata": {
       "type": "object",

--- a/examples/specialist_document/frontend/oim-project.json
+++ b/examples/specialist_document/frontend/oim-project.json
@@ -1,0 +1,196 @@
+{
+  "content_id": "574585b6-bf99-4cb1-be8b-628695f358d9",
+  "locale": "en",
+  "base_path": "/oim-projects/foo-bar-baz",
+  "title": "Example document",
+  "description": "Some example content",
+  "details": {
+    "body": "<h2 id=\"statutory-timetable\">Statutory timetable</h2>\n\n<table>\n  <thead>\n    <tr>\n      <th>Phase 1 date</th>\n      <th>Action</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>7 September 2015</td>\n      <td>Deadline for phase 1 decision (*)</td>\n    </tr>\n    <tr>\n      <td>10 to 24 July 2015</td>\n      <td>Invitation to comment</td>\n    </tr>\n    <tr>\n      <td>10 July 2015</td>\n      <td>Launch of merger inquiry</td>\n    </tr>\n  </tbody>\n</table>\n\n<p>(*) This date is the current statutory deadline by when the decision will be announced. If any change occurs, the information is refreshed as soon as practicable. However, the CMA cannot guarantee that the decision will be announced on or before this current deadline, as the deadline of a given case may change during the merger assessment process due to different reasons.</p>\n\n<h2 id=\"phase-1\">Phase 1</h2>\n\n<h3 id=\"invitation-to-comment-closes-24-july-2015\">Invitation to comment: closes 24 July 2015</h3>\n\n<p>10 July 2015: The CMA is considering whether it is or may be the case that this transaction has resulted in the creation of a relevant merger situation under the merger provisions of the Enterprise Act 2002 and, if so, whether the creation of that situation has resulted, or may be expected to result, in a substantial lessening of competition within any market or markets in the United Kingdom for goods or services.</p>\n\n<h3 id=\"launch-of-cma-merger-inquiry\">Launch of CMA merger inquiry</h3>\n\n<p>10 July 2015: The CMA announced the launch of its merger inquiry by notice to the parties.</p>\n\n<ul>\n  <li><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/559fc1b240f0b61564000047/Richemont-Yoox-NAP_commencement_of_initial_period_notice.pdf\">Commencement of initial period notice</a> (10.7.15)</li>\n</ul>\n\n<h3 id=\"contact\">Contact</h3>\n\n<p>Please send written representations about any competition issues to:</p>\n\n<div class=\"address\"><div class=\"adr org fn\"><p>\n\nSuzanne Van Scheijen\n<br />Competition and Markets Authority \n<br />Victoria House \n<br />Southampton Row \n<br />London \n<br />WC1B 4AD\n<br />\n</p></div></div>\n\n<p><a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#083;&#117;&#122;&#097;&#110;&#110;&#101;&#046;&#086;&#097;&#110;&#083;&#099;&#104;&#101;&#105;&#106;&#101;&#110;&#064;&#099;&#109;&#097;&#046;&#103;&#115;&#105;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#083;&#117;&#122;&#097;&#110;&#110;&#101;&#046;&#086;&#097;&#110;&#083;&#099;&#104;&#101;&#105;&#106;&#101;&#110;&#064;&#099;&#109;&#097;&#046;&#103;&#115;&#105;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p>\n",
+    "metadata": {
+      "bulk_published": false,
+      "oim_project_type": "annual-report",
+      "oim_project_state": "closed",
+      "oim_project_opened_date": "2015-07-10",
+      "oim_project_closed_date": "2015-08-20"
+    },
+    "max_cache_time": 10,
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2015-07-10T13:09:46+00:00"
+      }
+    ],
+    "headers": [
+      {
+        "text": "Statutory timetable",
+        "level": 2,
+        "id": "statutory-timetable"
+      },
+      {
+        "text": "Phase 1",
+        "level": 2,
+        "id": "phase-1",
+        "headers": [
+          {
+            "text": "Invitation to comment: closes 24 July 2015",
+            "level": 3,
+            "id": "invitation-to-comment-closes-24-july-2015"
+          },
+          {
+            "text": "Launch of CMA merger inquiry",
+            "level": 3,
+            "id": "launch-of-cma-merger-inquiry"
+          },
+          {
+            "text": "Contact",
+            "level": 3,
+            "id": "contact"
+          }
+        ]
+      }
+    ]
+  },
+  "public_updated_at": "2015-07-10T13:09:46+00:00",
+  "schema_name": "specialist_document",
+  "document_type": "oim_project",
+  "links": {
+    "organisations": [
+      {
+        "analytics_identifier": "D550",
+        "api_path": "/api/content/government/organisations/office-for-the-internal-market",
+        "base_path": "/government/organisations/office-for-the-internal-market",
+        "content_id": "b1123ceb-77e4-40fc-9526-83ad0ba7cf01",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2015-03-10T16:23:14Z",
+        "schema_name": "organisation",
+        "title": "Office for the Internal Market",
+        "withdrawn": false,
+        "details": {
+          "brand": "department-for-business-innovation-skills",
+          "logo": {
+            "formatted_title": "Office for the Internal Market",
+            "crest": null
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/office-for-the-internal-market",
+        "web_url": "https://www.gov.uk/government/organisations/office-for-the-internal-market"
+      }
+    ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/oim-projects",
+        "base_path": "/oim-projects",
+        "content_id": "4e4e33ff-271a-468a-b7a8-92d25f3f8ac0",
+        "description": "Find reports and updates on current and historical OIM projects",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Office for the Internal Market projects",
+        "withdrawn": false,
+        "details": {
+          "facets": [
+            {
+              "key": "oim_project_type",
+              "name": "OIM Project type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Annual report",
+                  "value": "annual-report"
+                },
+                {
+                  "label": "Five-yearly report",
+                  "value": "five-yearly-report"
+                },
+                {
+                  "label": "Discretionary report",
+                  "value": "discretionary-report"
+                },
+                {
+                  "label": "Advice/report on proposed regulatory provision",
+                  "value": "report-on-proposed-regulatory-provision"
+                },
+                {
+                  "label": "Report after regulatory provision is passed or made",
+                  "value": "report-after-regulatory-provision-is-passed-or-made"
+                },
+                {
+                  "label": "Report on provision considered to have detrimental effects",
+                  "value": "report-on-provision-considered-to-have-detrimental-effects"
+                }
+              ]
+            },
+            {
+              "key": "oim_project_state",
+              "name": "OIM Project state",
+              "type": "text",
+              "preposition": "which are",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Open",
+                  "value": "open"
+                },
+                {
+                  "label": "Closed",
+                  "value": "closed"
+                }
+              ]
+            },
+            {
+              "key": "oim_project_opened_date",
+              "name": "OIM Project opened",
+              "short_name": "Opened",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "oim_project_closed_date",
+              "name": "OIM Project closed",
+              "short_name": "Closed",
+              "type": "date",
+              "preposition": "closed",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ]
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/oim-projects",
+        "web_url": "https://www.gov.uk/oim-projects"
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "content_id": "27210998-66fb-4ff7-8fa8-7115936d296a",
+        "description": "Some example content",
+        "document_type": "cma_case",
+        "public_updated_at": "2015-10-01T11:00:38Z",
+        "schema_name": "specialist_document",
+        "title": "Example document",
+        "base_path": "/oim-projects/example-document",
+        "locale": "en",
+        "api_path": "/api/content/oim-projects/example-document",
+        "withdrawn": false,
+        "api_url": "https://www.gov.uk/api/content/oim-projects/example-document",
+        "web_url": "https://www.gov.uk/oim-projects/example-document",
+        "links": {
+        }
+      }
+    ]
+  },
+  "updated_at": "2017-06-30T15:44:11.073Z"
+}

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -54,6 +54,9 @@
         "$ref": "#/definitions/medical_safety_alert_metadata",
       },
       {
+        "$ref": "#/definitions/oim_project_metadata",
+      },
+      {
         "$ref": "#/definitions/protected_food_drink_name_metadata",
       },
       {
@@ -2047,6 +2050,41 @@
         },
       },
       issued_date: {
+        type: "string",
+        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
+      },
+    },
+  },
+  oim_project_metadata: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      bulk_published: {
+        type: "boolean",
+      },
+      oim_project_type: {
+        type: "string",
+        enum: [
+          "annual-report",
+          "five-yearly-report",
+          "discretionary-report",
+          "report-on-proposed-regulatory-provision",
+          "report-after-regulatory-provision-is-passed-or-made",
+          "report-on-provision-considered-to-have-detrimental-effects",
+        ],
+      },
+      oim_project_state: {
+        type: "string",
+        enum: [
+          "open",
+          "closed",
+        ],
+      },
+      oim_project_opened_date: {
+        type: "string",
+        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
+      },
+      oim_project_closed_date: {
         type: "string",
         pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
       },

--- a/formats/specialist_document.jsonnet
+++ b/formats/specialist_document.jsonnet
@@ -17,6 +17,7 @@
     "maib_report",
     "marine_notice",
     "medical_safety_alert",
+    "oim_project",
     "protected_food_drink_name",
     "raib_report",
     "research_for_development_output",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -97,6 +97,7 @@
 - official
 - official_statistics
 - official_statistics_announcement
+- oim_project
 - open_consultation
 - oral_statement
 - organisation


### PR DESCRIPTION
Add OIM_project to specialist document schema.

- Related specialist publisher [PR](https://github.com/alphagov/specialist-publisher/pull/1910)
- Related search api [PR](https://github.com/alphagov/search-api/pull/2326)
- [Trello](https://trello.com/c/vN0SFEyb/2700-create-new-specialist-document-and-finder-office-for-the-internal-market-projects)