### PR TITLE
Simplify the URI required for redirect destinations

### DIFF
--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -182,11 +182,6 @@
     }
   },
   "definitions": {
-    "absolute_fullpath": {
-      "description": "A path with optional query string and/or fragment.",
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
-    },
     "absolute_path": {
       "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
@@ -340,11 +335,6 @@
           }
         }
       }
-    },
-    "govuk_subdomain_url": {
-      "description": "A URL under the gov.uk domain with optional query string and/or fragment.",
-      "type": "string",
-      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
     },
     "guid": {
       "type": "string",
@@ -502,14 +492,7 @@
       "properties": {
         "destination": {
           "type": "string",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/absolute_fullpath"
-            },
-            {
-              "$ref": "#/definitions/govuk_subdomain_url"
-            }
-          ]
+          "format": "uri"
         },
         "path": {
           "$ref": "#/definitions/absolute_path"

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -197,11 +197,6 @@
     }
   },
   "definitions": {
-    "absolute_fullpath": {
-      "description": "A path with optional query string and/or fragment.",
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
-    },
     "absolute_path": {
       "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
@@ -362,11 +357,6 @@
         "null"
       ]
     },
-    "govuk_subdomain_url": {
-      "description": "A URL under the gov.uk domain with optional query string and/or fragment.",
-      "type": "string",
-      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
-    },
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
@@ -512,14 +502,7 @@
       "properties": {
         "destination": {
           "type": "string",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/absolute_fullpath"
-            },
-            {
-              "$ref": "#/definitions/govuk_subdomain_url"
-            }
-          ]
+          "format": "uri"
         },
         "path": {
           "$ref": "#/definitions/absolute_path"

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -114,11 +114,6 @@
     }
   },
   "definitions": {
-    "absolute_fullpath": {
-      "description": "A path with optional query string and/or fragment.",
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
-    },
     "absolute_path": {
       "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
@@ -159,11 +154,6 @@
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
-    },
-    "govuk_subdomain_url": {
-      "description": "A URL under the gov.uk domain with optional query string and/or fragment.",
-      "type": "string",
-      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
     },
     "guid": {
       "type": "string",
@@ -302,14 +292,7 @@
       "properties": {
         "destination": {
           "type": "string",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/absolute_fullpath"
-            },
-            {
-              "$ref": "#/definitions/govuk_subdomain_url"
-            }
-          ]
+          "format": "uri"
         },
         "path": {
           "$ref": "#/definitions/absolute_path"

--- a/formats/shared/definitions/routes_redirects.jsonnet
+++ b/formats/shared/definitions/routes_redirects.jsonnet
@@ -62,17 +62,7 @@
           "exact",
         ],
       },
-      destination: {
-        type: "string",
-        anyOf: [
-          {
-            "$ref": "#/definitions/absolute_fullpath",
-          },
-          {
-            "$ref": "#/definitions/govuk_subdomain_url",
-          },
-        ],
-      },
+      destination: { type: "string", format: "uri" },
       segments_mode: {
         enum: [
           "preserve",
@@ -81,10 +71,5 @@
         description: "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
       },
     },
-  },
-  govuk_subdomain_url: {
-    type: "string",
-    pattern: "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
-    description: "A URL under the gov.uk domain with optional query string and/or fragment.",
-  },
+  }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/OE0mGWzN/1630-create-pharmacy-collect-short-urls-for-13-september

This changes the schema validation for redirect destinations from
something quite restrictive to something much more permissive. The
reason for taking a permissive approach here is because of duplication
of validation efforts.

Currently Publishing API has an involved redirect destination validation
process, which is used for both unpublishing and individual redirects [1].
This schema has not kept up with this validation and is currently out of
sync. Rather than trying to continue a process of keeping a schema and a
Rails validator in sync, it seems simpler and more accurate to make the
schema permissive and rely on the Publishing API validator as the
validating entity.

The prompt for this change was trying to adjust Short URL Manager to
allow redirects to hosts off GOV.UK (nhs.uk) this had the pain point
that Short URL Manager validates the URL, then Publishing API validates
the URL via Content Schema, and then Publishing API validates the URL
again through its Rails validator. The distribution of this logic is a
pain point.

[1]: https://github.com/alphagov/publishing-api/blob/3717c4057c0c05f9846a122ceb5972e559117d7c/app/validators/routes_and_redirects_validator.rb#L122