### PR TITLE
Add account-api to the list of allowed publishing apps

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -560,6 +560,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -696,6 +696,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -325,6 +325,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -530,6 +530,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -647,6 +647,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -276,6 +276,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -654,6 +654,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -785,6 +785,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -410,6 +410,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -533,6 +533,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -650,6 +650,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -279,6 +279,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -625,6 +625,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -742,6 +742,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -371,6 +371,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -962,6 +962,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1094,6 +1094,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -754,6 +754,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -761,6 +761,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -894,6 +894,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -508,6 +508,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -523,6 +523,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -640,6 +640,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -269,6 +269,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -711,6 +711,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -836,6 +836,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -495,6 +495,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -788,6 +788,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -918,6 +918,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -580,6 +580,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -656,6 +656,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -789,6 +789,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -442,6 +442,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -595,6 +595,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -712,6 +712,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -341,6 +341,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/external_content/notification/schema.json
+++ b/dist/formats/external_content/notification/schema.json
@@ -512,6 +512,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -269,6 +269,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -543,6 +543,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -617,6 +617,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -349,6 +349,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet_group/frontend/schema.json
+++ b/dist/formats/facet_group/frontend/schema.json
@@ -477,6 +477,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet_group/notification/schema.json
+++ b/dist/formats/facet_group/notification/schema.json
@@ -546,6 +546,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -288,6 +288,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -539,6 +539,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -666,6 +666,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -292,6 +292,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -565,6 +565,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -695,6 +695,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -349,6 +349,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -907,6 +907,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1038,6 +1038,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -643,6 +643,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -677,6 +677,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -796,6 +796,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -421,6 +421,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -703,6 +703,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -820,6 +820,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -449,6 +449,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -729,6 +729,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -846,6 +846,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -475,6 +475,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/get_involved/frontend/schema.json
+++ b/dist/formats/get_involved/frontend/schema.json
@@ -611,6 +611,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/get_involved/notification/schema.json
+++ b/dist/formats/get_involved/notification/schema.json
@@ -728,6 +728,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/get_involved/publisher_v2/schema.json
+++ b/dist/formats/get_involved/publisher_v2/schema.json
@@ -357,6 +357,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -467,6 +467,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -495,6 +495,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -270,6 +270,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/government/frontend/schema.json
+++ b/dist/formats/government/frontend/schema.json
@@ -537,6 +537,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/government/notification/schema.json
+++ b/dist/formats/government/notification/schema.json
@@ -654,6 +654,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/government/publisher_v2/schema.json
+++ b/dist/formats/government/publisher_v2/schema.json
@@ -283,6 +283,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -589,6 +589,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -725,6 +725,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -354,6 +354,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -560,6 +560,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -696,6 +696,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -325,6 +325,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/history/frontend/schema.json
+++ b/dist/formats/history/frontend/schema.json
@@ -529,6 +529,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/history/notification/schema.json
+++ b/dist/formats/history/notification/schema.json
@@ -646,6 +646,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/history/publisher_v2/schema.json
+++ b/dist/formats/history/publisher_v2/schema.json
@@ -275,6 +275,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -645,6 +645,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -762,6 +762,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -391,6 +391,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -649,6 +649,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -766,6 +766,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -395,6 +395,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -461,6 +461,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -516,6 +516,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -269,6 +269,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -570,6 +570,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -684,6 +684,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -334,6 +334,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -457,6 +457,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -501,6 +501,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -265,6 +265,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -579,6 +579,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -715,6 +715,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -344,6 +344,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -652,6 +652,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -788,6 +788,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -417,6 +417,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -562,6 +562,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -688,6 +688,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -285,6 +285,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -639,6 +639,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -780,6 +780,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -403,6 +403,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -647,6 +647,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -788,6 +788,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -411,6 +411,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/ministers_index/frontend/schema.json
+++ b/dist/formats/ministers_index/frontend/schema.json
@@ -529,6 +529,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/ministers_index/notification/schema.json
+++ b/dist/formats/ministers_index/notification/schema.json
@@ -646,6 +646,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/dist/formats/ministers_index/publisher_v2/schema.json
@@ -275,6 +275,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -590,6 +590,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -707,6 +707,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -336,6 +336,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -724,6 +724,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -869,6 +869,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -500,6 +500,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -999,6 +999,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -1172,6 +1172,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -745,6 +745,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -606,6 +606,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -723,6 +723,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -352,6 +352,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -592,6 +592,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -728,6 +728,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -357,6 +357,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -569,6 +569,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -705,6 +705,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -334,6 +334,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -839,6 +839,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -960,6 +960,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -585,6 +585,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -901,6 +901,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1039,6 +1039,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -693,6 +693,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -430,6 +430,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -445,6 +445,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -246,6 +246,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -600,6 +600,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -755,6 +755,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -373,6 +373,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -548,6 +548,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -683,6 +683,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -301,6 +301,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -581,6 +581,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -706,6 +706,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -343,6 +343,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -523,6 +523,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -640,6 +640,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -269,6 +269,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -539,6 +539,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -660,6 +660,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -281,6 +281,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -572,6 +572,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -689,6 +689,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -318,6 +318,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -552,6 +552,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -674,6 +674,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -279,6 +279,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -614,6 +614,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -750,6 +750,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -379,6 +379,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -622,6 +622,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -758,6 +758,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -387,6 +387,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/smart_answer/frontend/schema.json
+++ b/dist/formats/smart_answer/frontend/schema.json
@@ -559,6 +559,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/smart_answer/notification/schema.json
+++ b/dist/formats/smart_answer/notification/schema.json
@@ -676,6 +676,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/dist/formats/smart_answer/publisher_v2/schema.json
@@ -305,6 +305,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -676,6 +676,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -793,6 +793,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -443,6 +443,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2693,6 +2693,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2830,6 +2830,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2495,6 +2495,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -680,6 +680,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -824,6 +824,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -423,6 +423,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -780,6 +780,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -901,6 +901,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -555,6 +555,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -562,6 +562,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -678,6 +678,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -309,6 +309,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -527,6 +527,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -613,6 +613,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -354,6 +354,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -582,6 +582,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -699,6 +699,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -328,6 +328,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -553,6 +553,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -686,6 +686,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -291,6 +291,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -540,6 +540,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -654,6 +654,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -275,6 +275,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -537,6 +537,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -654,6 +654,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -283,6 +283,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -633,6 +633,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -769,6 +769,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -398,6 +398,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -722,6 +722,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -864,6 +864,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -481,6 +481,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -547,6 +547,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -667,6 +667,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -290,6 +290,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -546,6 +546,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -663,6 +663,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -292,6 +292,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -445,6 +445,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -593,6 +593,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -710,6 +710,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -339,6 +339,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -569,6 +569,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -700,6 +700,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -323,6 +323,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -698,6 +698,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -829,6 +829,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -454,6 +454,7 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections-publisher",

--- a/formats/shared/definitions/publishing_app.jsonnet
+++ b/formats/shared/definitions/publishing_app.jsonnet
@@ -3,6 +3,7 @@
     description: "The application that published this item.",
     type: "string",
     enum: [
+      "account-api",
       "calculators",
       "calendars",
       "collections-publisher",


### PR DESCRIPTION
We're going to publish the "sorting hat" page (a navigation page listing other government accounts) from account-api.  We want it to appear in search, so it's not a special route, so we can't use special-route-publisher.  We'll do it as a help page (with the content item containing the searchable text) with some custom rendering behaviour.

---

[Trello card](https://trello.com/c/FbsTQJ0z/1008-build-sorting-hat-page-v1)