### PR TITLE
Add new report type for `Marine Accident Investigation Branch reports`.

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2173,6 +2173,7 @@
           "type": "string",
           "enum": [
             "investigation-report",
+            "investigation-report-on-behalf-of-red-ensign-group",
             "safety-bulletin",
             "completed-preliminary-examination",
             "overseas-report",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2287,6 +2287,7 @@
           "type": "string",
           "enum": [
             "investigation-report",
+            "investigation-report-on-behalf-of-red-ensign-group",
             "safety-bulletin",
             "completed-preliminary-examination",
             "overseas-report",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1956,6 +1956,7 @@
           "type": "string",
           "enum": [
             "investigation-report",
+            "investigation-report-on-behalf-of-red-ensign-group",
             "safety-bulletin",
             "completed-preliminary-examination",
             "overseas-report",

--- a/examples/finder/frontend/maib-reports.json
+++ b/examples/finder/frontend/maib-reports.json
@@ -47,6 +47,10 @@
             "value": "investigation-report"
           },
           {
+            "label": "Investigation report on behalf of Red Ensign Group",
+            "value": "investigation-report-on-behalf-of-red-ensign-group"
+          },
+          {
             "label": "Safety bulletin",
             "value": "safety-bulletin"
           },

--- a/examples/specialist_document/frontend/maib-reports.json
+++ b/examples/specialist_document/frontend/maib-reports.json
@@ -126,6 +126,10 @@
                   "value": "investigation-report"
                 },
                 {
+                  "label": "Investigation report on behalf of Red Ensign Group",
+                  "value": "investigation-report-on-behalf-of-red-ensign-group"
+                },
+                {
                   "label": "Safety bulletin",
                   "value": "safety-bulletin"
                 },

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -1929,6 +1929,7 @@
         type: "string",
         enum: [
           "investigation-report",
+          "investigation-report-on-behalf-of-red-ensign-group",
           "safety-bulletin",
           "completed-preliminary-examination",
           "overseas-report",


### PR DESCRIPTION
Added a new report type: 'Investigation report on behalf of Red Ensign Group', following 'Investigation report' type.

[Trello card](https://trello.com/c/GLTNl1B4/2709-add-new-report-type-for-marine-accident-investigation-branch-reports-3)

Related PR's:
https://github.com/alphagov/specialist-publisher/pull/1927
https://github.com/alphagov/search-api/pull/2333