### PR TITLE
Remove body requirement from Get Involved schema

### DIFF
--- a/dist/formats/get_involved/frontend/schema.json
+++ b/dist/formats/get_involved/frontend/schema.json
@@ -298,9 +298,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "body"
-      ],
       "additionalProperties": false,
       "properties": {
         "body": {

--- a/dist/formats/get_involved/notification/schema.json
+++ b/dist/formats/get_involved/notification/schema.json
@@ -398,9 +398,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "body"
-      ],
       "additionalProperties": false,
       "properties": {
         "body": {

--- a/dist/formats/get_involved/publisher_v2/schema.json
+++ b/dist/formats/get_involved/publisher_v2/schema.json
@@ -173,9 +173,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "body"
-      ],
       "additionalProperties": false,
       "properties": {
         "body": {

--- a/formats/get_involved.jsonnet
+++ b/formats/get_involved.jsonnet
@@ -5,7 +5,6 @@
     details: {
       type: "object",
       additionalProperties: false,
-      required: ["body"],
       properties: {
         body: { type: "string" },
         take_part_pages: {


### PR DESCRIPTION
It was preventing publishing from Whitehall. While the body can contain information, it does not always especially when coming from Whitehall as a publishing source. Disabling the pure requirement for it allows for continued publishing from Whitehall while still giving the option of changing the publishing source in the future (e.g. when we migrate away from Whitehall entirely).

The only file manually changed was the .jsonnet, all others are generated automatically as per process.

https://trello.com/c/EZt2QYbz/2717-migrate-rendering-of-government-get-involved-from-whitehall-frontend-to-government-frontend