### PR TITLE
Rename 'Unsafe Product Report' to 'Product Safety Report'

### DIFF
--- a/examples/specialist_document/frontend/product-safety-alert.json
+++ b/examples/specialist_document/frontend/product-safety-alert.json
@@ -112,8 +112,8 @@
                   "value": "safety-alert"
                 },
                 {
-                  "label": "Unsafe product report",
-                  "value": "unsafe-product-report"
+                  "label": "Product safety report",
+                  "value": "product-safety-report"
                 },
                 {
                   "label": "Recall",


### PR DESCRIPTION
This was a late request in
https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3

Follows on from #1077.