### PR TITLE
Add Account API to the list of rendering apps

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -616,6 +616,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -747,6 +747,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -365,6 +365,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -586,6 +586,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -698,6 +698,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -316,6 +316,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -710,6 +710,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -836,6 +836,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -450,6 +450,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -589,6 +589,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -701,6 +701,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -319,6 +319,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -681,6 +681,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -793,6 +793,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -411,6 +411,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -1018,6 +1018,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1145,6 +1145,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -794,6 +794,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -817,6 +817,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -945,6 +945,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -548,6 +548,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -579,6 +579,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -691,6 +691,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -309,6 +309,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -767,6 +767,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -887,6 +887,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -535,6 +535,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -844,6 +844,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -969,6 +969,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -620,6 +620,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -712,6 +712,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -840,6 +840,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -482,6 +482,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -651,6 +651,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -763,6 +763,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -381,6 +381,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -599,6 +599,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -668,6 +668,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet/publisher_v2/schema.json
+++ b/dist/formats/facet/publisher_v2/schema.json
@@ -389,6 +389,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet_group/frontend/schema.json
+++ b/dist/formats/facet_group/frontend/schema.json
@@ -533,6 +533,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet_group/notification/schema.json
+++ b/dist/formats/facet_group/notification/schema.json
@@ -597,6 +597,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet_group/publisher_v2/schema.json
+++ b/dist/formats/facet_group/publisher_v2/schema.json
@@ -328,6 +328,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -595,6 +595,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -717,6 +717,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/facet_value/publisher_v2/schema.json
+++ b/dist/formats/facet_value/publisher_v2/schema.json
@@ -332,6 +332,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -621,6 +621,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -746,6 +746,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -389,6 +389,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -963,6 +963,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1089,6 +1089,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -683,6 +683,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -733,6 +733,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -847,6 +847,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -461,6 +461,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -760,6 +760,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -872,6 +872,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -490,6 +490,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -786,6 +786,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -898,6 +898,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -516,6 +516,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/get_involved/frontend/schema.json
+++ b/dist/formats/get_involved/frontend/schema.json
@@ -664,6 +664,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/get_involved/notification/schema.json
+++ b/dist/formats/get_involved/notification/schema.json
@@ -776,6 +776,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/get_involved/publisher_v2/schema.json
+++ b/dist/formats/get_involved/publisher_v2/schema.json
@@ -394,6 +394,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/government/frontend/schema.json
+++ b/dist/formats/government/frontend/schema.json
@@ -593,6 +593,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/government/notification/schema.json
+++ b/dist/formats/government/notification/schema.json
@@ -705,6 +705,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/government/publisher_v2/schema.json
+++ b/dist/formats/government/publisher_v2/schema.json
@@ -323,6 +323,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -645,6 +645,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -776,6 +776,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -394,6 +394,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -616,6 +616,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -747,6 +747,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -365,6 +365,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/history/frontend/schema.json
+++ b/dist/formats/history/frontend/schema.json
@@ -585,6 +585,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/history/notification/schema.json
+++ b/dist/formats/history/notification/schema.json
@@ -697,6 +697,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/history/publisher_v2/schema.json
+++ b/dist/formats/history/publisher_v2/schema.json
@@ -315,6 +315,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -701,6 +701,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -813,6 +813,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -431,6 +431,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -705,6 +705,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -817,6 +817,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -435,6 +435,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -517,6 +517,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -567,6 +567,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -309,6 +309,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -626,6 +626,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -735,6 +735,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -374,6 +374,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/dist/formats/knowledge_alpha/frontend/schema.json
@@ -513,6 +513,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/knowledge_alpha/notification/schema.json
+++ b/dist/formats/knowledge_alpha/notification/schema.json
@@ -552,6 +552,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -305,6 +305,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -635,6 +635,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -766,6 +766,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -384,6 +384,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -708,6 +708,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -839,6 +839,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -457,6 +457,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -618,6 +618,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -739,6 +739,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -325,6 +325,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -695,6 +695,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -831,6 +831,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -443,6 +443,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -703,6 +703,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -839,6 +839,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -451,6 +451,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/ministers_index/frontend/schema.json
+++ b/dist/formats/ministers_index/frontend/schema.json
@@ -585,6 +585,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/ministers_index/notification/schema.json
+++ b/dist/formats/ministers_index/notification/schema.json
@@ -697,6 +697,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/dist/formats/ministers_index/publisher_v2/schema.json
@@ -315,6 +315,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -646,6 +646,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -758,6 +758,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -376,6 +376,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -780,6 +780,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -920,6 +920,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -540,6 +540,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -1055,6 +1055,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -1223,6 +1223,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -785,6 +785,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -662,6 +662,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -774,6 +774,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -392,6 +392,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -648,6 +648,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -779,6 +779,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -397,6 +397,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -625,6 +625,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -756,6 +756,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -374,6 +374,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -896,6 +896,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -1012,6 +1012,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -626,6 +626,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -957,6 +957,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1090,6 +1090,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -733,6 +733,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -656,6 +656,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -806,6 +806,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -413,6 +413,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -604,6 +604,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -734,6 +734,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -341,6 +341,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -637,6 +637,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -757,6 +757,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -383,6 +383,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -579,6 +579,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -691,6 +691,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -309,6 +309,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -595,6 +595,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -711,6 +711,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -321,6 +321,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -628,6 +628,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -740,6 +740,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -358,6 +358,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -608,6 +608,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -725,6 +725,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -319,6 +319,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -670,6 +670,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -801,6 +801,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -419,6 +419,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -678,6 +678,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -809,6 +809,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -427,6 +427,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/smart_answer/frontend/schema.json
+++ b/dist/formats/smart_answer/frontend/schema.json
@@ -615,6 +615,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/smart_answer/notification/schema.json
+++ b/dist/formats/smart_answer/notification/schema.json
@@ -727,6 +727,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/dist/formats/smart_answer/publisher_v2/schema.json
@@ -345,6 +345,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -733,6 +733,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -845,6 +845,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -484,6 +484,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2877,6 +2877,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -3009,6 +3009,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2663,6 +2663,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -736,6 +736,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -875,6 +875,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -463,6 +463,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -836,6 +836,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -952,6 +952,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -595,6 +595,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -618,6 +618,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -729,6 +729,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -349,6 +349,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -583,6 +583,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -664,6 +664,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -394,6 +394,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -638,6 +638,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -750,6 +750,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -368,6 +368,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -609,6 +609,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -737,6 +737,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -331,6 +331,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -596,6 +596,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -705,6 +705,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -315,6 +315,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -593,6 +593,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -705,6 +705,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -323,6 +323,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -689,6 +689,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -820,6 +820,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -438,6 +438,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -778,6 +778,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -915,6 +915,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -532,6 +532,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -603,6 +603,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -718,6 +718,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -341,6 +341,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -602,6 +602,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -714,6 +714,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -332,6 +332,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -649,6 +649,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -761,6 +761,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -379,6 +379,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -625,6 +625,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -751,6 +751,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -363,6 +363,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -754,6 +754,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -880,6 +880,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -494,6 +494,7 @@
       "description": "The application that renders this item.",
       "type": "string",
       "enum": [
+        "account-api",
         "calculators",
         "calendars",
         "collections",

--- a/formats/shared/definitions/rendering_app.jsonnet
+++ b/formats/shared/definitions/rendering_app.jsonnet
@@ -3,6 +3,7 @@
     description: "The application that renders this item.",
     type: "string",
     enum: [
+      "account-api",
       "calculators",
       "calendars",
       "collections",


### PR DESCRIPTION
The Account API can be used to personalise pages for logged in users.
Following [Account API ADR 2][1] this is intended to approached as a
progressive enhancement via javascript in a browser.

As such these endpoints can now be called and will return payloads of
JSON, sometimes containing rendered HTML to be added into application
frontends.

As we wish to proxy these routes to account-api we will need to identify
account-api a rendering app.

[1]: https://github.com/alphagov/account-api/blob/main/docs/adr/002-progressive-enhancement.md