### PR TITLE
Fix product safety alerts 'risk level' option

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2463,7 +2463,7 @@
             "high",
             "medium",
             "low",
-            "not provided"
+            "not-provided"
           ]
         }
       }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2600,7 +2600,7 @@
             "high",
             "medium",
             "low",
-            "not provided"
+            "not-provided"
           ]
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2265,7 +2265,7 @@
             "high",
             "medium",
             "low",
-            "not provided"
+            "not-provided"
           ]
         }
       }

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -2122,7 +2122,7 @@
           "high",
           "medium",
           "low",
-          "not provided",
+          "not-provided",
         ],
       },
       product_category: {


### PR DESCRIPTION
The value needs to be 'not-provided' to match the input name given
in HTML:
https://github.com/alphagov/govuk-content-schemas/pull/1081/files#diff-347660f78070dce5f87642959d0b58ec9e51cfc53c84bd2b2eb3ff5f98143fd4R150

Tweaking the schema should fix https://govuk.zendesk.com/agent/tickets/4882031[](https://github.com/ChrisBAshton).