### PR TITLE
Replace mainstream_browse_type with mainstream_browse_origin in Topic schema

### DIFF
--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -309,8 +309,9 @@
         "internal_name": {
           "$ref": "#/definitions/taxonomy_internal_name"
         },
-        "mainstream_browse_type": {
-          "type": "boolean"
+        "mainstream_browse_origin": {
+          "description": "Content id of Mainstream browse page the topic originated from as a part of unified topic system work",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -413,8 +413,9 @@
         "internal_name": {
           "$ref": "#/definitions/taxonomy_internal_name"
         },
-        "mainstream_browse_type": {
-          "type": "boolean"
+        "mainstream_browse_origin": {
+          "description": "Content id of Mainstream browse page the topic originated from as a part of unified topic system work",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -177,8 +177,9 @@
         "internal_name": {
           "$ref": "#/definitions/taxonomy_internal_name"
         },
-        "mainstream_browse_type": {
-          "type": "boolean"
+        "mainstream_browse_origin": {
+          "description": "Content id of Mainstream browse page the topic originated from as a part of unified topic system work",
+          "type": "string"
         }
       }
     },

--- a/formats/topic.jsonnet
+++ b/formats/topic.jsonnet
@@ -11,8 +11,9 @@
         groups: {
           "$ref": "#/definitions/topic_groups",
         },
-        mainstream_browse_type: {
-          "type": "boolean"
+        mainstream_browse_origin: {
+          type: "string",
+          description: "Content id of Mainstream browse page the topic originated from as a part of unified topic system work"
         }
       },
     },


### PR DESCRIPTION
We want to reference the Content id of Mainstream browse page the topic originated from as a part of unified topic system work.

Until the work is completed we will need to keep the Mainstream browse page and
the cloned Topic is sync. Since other attributes of the Mainstream browse page
such as title or slug can change, this adds a unique reference we can use to
identify the cloned Topic.

The presence of this attribute can still acts as a flag.

It may also be useful to include reverse association in the Mainstream browse page schema to the cloned Topic's content_id.