### PR TITLE
Update manual examples

### DIFF
--- a/examples/hmrc_manual/frontend/vat-government-public-bodies.json
+++ b/examples/hmrc_manual/frontend/vat-government-public-bodies.json
@@ -6,6 +6,7 @@
   "locale": "en",
   "updated_at": "2015-03-05T15:16:29.904Z",
   "public_updated_at": "2015-02-11T13:45:00.000+00:00",
+  "first_published_at": "2015-02-11T13:45:00.000+00:00",
   "details": {
     "child_section_groups": [
       {
@@ -104,7 +105,7 @@
         "change_note": "Updated content",
         "section_id": "VATGPB5350",
         "title": "Police authorities: summary of activities: liabilities I to M",
-        "published_at": "2015-03-05T15:11:32+00:00",
+        "published_at": "2014-03-05T15:11:32+00:00",
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5350"
       }
     ],

--- a/examples/hmrc_manual_section/frontend/vatgpb2000.json
+++ b/examples/hmrc_manual_section/frontend/vatgpb2000.json
@@ -9,7 +9,9 @@
   "details": {
     "body": "\n",
     "section_id": "VATGPB2000",
-    "breadcrumbs": [],
+    "breadcrumbs": [
+
+    ],
     "child_section_groups": [
       {
         "child_sections": [

--- a/examples/hmrc_manual_section/frontend/vatgpb2000.json
+++ b/examples/hmrc_manual_section/frontend/vatgpb2000.json
@@ -1,6 +1,6 @@
 {
   "content_id": "2189bae1-a94e-4f90-917b-ffe25ec9ac4d",
-  "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+  "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2000",
   "title": "Introduction: contents",
   "description": "",
   "locale": "en",
@@ -8,48 +8,46 @@
   "public_updated_at": "2015-02-10T14:52:10.000+00:00",
   "details": {
     "body": "\n",
-    "section_id": "VATGPB1000",
-    "breadcrumbs": [
-
-    ],
+    "section_id": "VATGPB2000",
+    "breadcrumbs": [],
     "child_section_groups": [
       {
         "child_sections": [
           {
-            "section_id": "VATGPB1100",
+            "section_id": "VATGPB2100",
             "title": "Introduction: scope of the manual",
             "description": "",
-            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1100"
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2100"
           },
           {
-            "section_id": "VATGPB1200",
+            "section_id": "VATGPB2200",
             "title": "Introduction: release of information",
             "description": "",
-            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1200"
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2200"
           },
           {
-            "section_id": "VATGPB1300",
+            "section_id": "VATGPB2300",
             "title": "Introduction: how to use the manual",
             "description": "",
-            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1300"
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2300"
           },
           {
-            "section_id": "VATGPB1400",
+            "section_id": "VATGPB2400",
             "title": "Introduction: Notice 749",
             "description": "",
-            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1400"
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2400"
           },
           {
-            "section_id": "VATGPB1500",
+            "section_id": "VATGPB2500",
             "title": "Introduction: representative bodies",
             "description": "",
-            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1500"
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2500"
           },
           {
-            "section_id": "VATGPB1600",
+            "section_id": "VATGPB2600",
             "title": "Introduction: HMRC contacts",
             "description": "",
-            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1600"
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2600"
           }
         ]
       }
@@ -70,10 +68,10 @@
       {
         "content_id": "2189bae1-a94e-4f90-917b-ffe25ec9ac4d",
         "title": "Introduction: contents",
-        "api_path": "/api/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
-        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
-        "api_url": "https://www.gov.uk/api/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
-        "web_url": "https://www.gov.uk/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        "api_path": "/api/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2000",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2000",
+        "api_url": "https://www.gov.uk/api/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2000",
+        "web_url": "https://www.gov.uk/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2000",
         "locale": "en"
       }
     ],

--- a/examples/manual/frontend/content-design.json
+++ b/examples/manual/frontend/content-design.json
@@ -88,7 +88,8 @@
         "public_updated_at": "2017-05-19T13:59:21Z",
         "schema_name": "topic",
         "withdrawn": false,
-        "links": {},
+        "links": {
+        },
         "api_url": "https://www.gov.uk/api/content/topic/government-digital-guidance/content-publishing",
         "web_url": "https://www.gov.uk/topic/government-digital-guidance/content-publishing"
       }
@@ -104,13 +105,21 @@
         "document_type": "organisation",
         "schema_name": "organisation",
         "withdrawn": false,
-        "details":  {
-          "logo": {"crest": "single-identity", "formatted_title": "Government Digital Service"},
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Government Digital Service"
+          },
           "brand": "cabinet-office",
           "default_news_image": null,
-          "organisation_govuk_status": {"url": null, "status": "live", "updated_at": null}
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
         },
-        "links": {},
+        "links": {
+        },
         "api_url": "https://www.gov.uk/api/content/government/organisations/government-digital-service",
         "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
       }
@@ -126,13 +135,21 @@
         "document_type": "organisation",
         "schema_name": "organisation",
         "withdrawn": false,
-        "details":  {
-          "logo": {"crest": "single-identity", "formatted_title": "Government Digital Service"},
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Government Digital Service"
+          },
           "brand": "cabinet-office",
           "default_news_image": null,
-          "organisation_govuk_status": {"url": null, "status": "live", "updated_at": null}
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
         },
-        "links": {},
+        "links": {
+        },
         "api_url": "https://www.gov.uk/api/content/government/organisations/government-digital-service",
         "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
       }

--- a/examples/manual/frontend/content-design.json
+++ b/examples/manual/frontend/content-design.json
@@ -6,6 +6,7 @@
   "locale": "en",
   "updated_at": "2015-04-27T12:54:38.685Z",
   "public_updated_at": "2015-04-27T12:54:27.000+00:00",
+  "first_published_at": "2015-04-27T12:54:27.000+00:00",
   "details": {
     "body": "<p>Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.\nSumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.\nNo eum mutat soleat definiebas, ut argumentum efficiantur delicatissimi ius. At feugait adversarium vel. At cum mutat numquam graecis. Sit appareat adolescens constituto eu, te eleifend postulant theophrastus eam\nIf you would like to receive email updates for daily ice cream flavours, send us a hand written note.\nVel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne.If you like yoga <a href=\"/lloydsfactsheet\">click here</a>.</p>\n",
     "child_section_groups": [
@@ -53,7 +54,7 @@
         "base_path": "/guidance/content-design/content-types",
         "title": "Content types",
         "change_note": "New section added.",
-        "published_at": "2014-10-06T19:49:25Z"
+        "published_at": "2013-10-06T19:49:25Z"
       }
     ],
     "organisations": [
@@ -74,6 +75,66 @@
         "api_url": "https://www.gov.uk/api/content/guidance/content-design",
         "web_url": "https://www.gov.uk/guidance/content-design",
         "locale": "en"
+      }
+    ],
+    "topics": [
+      {
+        "content_id": "4dfaf37e-33ea-4f56-9d06-24cebd0f6995",
+        "title": "Content and publishing",
+        "locale": "en",
+        "api_path": "/api/content/topic/government-digital-guidance/content-publishing",
+        "base_path": "/topic/government-digital-guidance/content-publishing",
+        "document_type": "topic",
+        "public_updated_at": "2017-05-19T13:59:21Z",
+        "schema_name": "topic",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/topic/government-digital-guidance/content-publishing",
+        "web_url": "https://www.gov.uk/topic/government-digital-guidance/content-publishing"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service",
+        "locale": "en",
+        "analytics_identifier": "OT1056",
+        "api_path": "/api/content/government/organisations/government-digital-service",
+        "base_path": "/government/organisations/government-digital-service",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details":  {
+          "logo": {"crest": "single-identity", "formatted_title": "Government Digital Service"},
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {"url": null, "status": "live", "updated_at": null}
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/organisations/government-digital-service",
+        "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service",
+        "locale": "en",
+        "analytics_identifier": "OT1056",
+        "api_path": "/api/content/government/organisations/government-digital-service",
+        "base_path": "/government/organisations/government-digital-service",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details":  {
+          "logo": {"crest": "single-identity", "formatted_title": "Government Digital Service"},
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {"url": null, "status": "live", "updated_at": null}
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/organisations/government-digital-service",
+        "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
       }
     ]
   },

--- a/examples/manual_section/frontend/what-is-content-design.json
+++ b/examples/manual_section/frontend/what-is-content-design.json
@@ -52,14 +52,17 @@
       {
         "content_id": "1326d2a4-849f-44d6-b84a-f81728e62483",
         "title": "Content design: planning, writing and managing content",
-        "locale": "en", "api_path": "/api/content/guidance/content-design",
+        "locale": "en",
+        "api_path": "/api/content/guidance/content-design",
         "base_path": "/guidance/content-design",
         "document_type": "manual",
         "public_updated_at": "2022-02-18T10:49:44Z",
         "schema_name": "manual",
-        "withdrawn":false,
-        "links": {},
-        "api_url": "https://www.gov.uk/api/content/guidance/content-design", "web_url": "https://www.gov.uk/guidance/content-design"
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/guidance/content-design",
+        "web_url": "https://www.gov.uk/guidance/content-design"
       }
     ]
   },

--- a/examples/manual_section/frontend/what-is-content-design.json
+++ b/examples/manual_section/frontend/what-is-content-design.json
@@ -47,6 +47,20 @@
         "web_url": "https://www.gov.uk/guidance/content-design/what-is-content-design",
         "locale": "en"
       }
+    ],
+    "manual": [
+      {
+        "content_id": "1326d2a4-849f-44d6-b84a-f81728e62483",
+        "title": "Content design: planning, writing and managing content",
+        "locale": "en", "api_path": "/api/content/guidance/content-design",
+        "base_path": "/guidance/content-design",
+        "document_type": "manual",
+        "public_updated_at": "2022-02-18T10:49:44Z",
+        "schema_name": "manual",
+        "withdrawn":false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/guidance/content-design", "web_url": "https://www.gov.uk/guidance/content-design"
+      }
     ]
   },
   "schema_name": "manual_section",


### PR DESCRIPTION
This PR updates the manual related example schemas for frontend. This is needed as some schemas are missing data (links, timestamps etc), which should be present. I've also updated some of the data to make life easier in testing, which is taken advantage of in https://github.com/alphagov/government-frontend/pull/2424.

Trello:
https://trello.com/c/YmmLFXu5/1127-manuals-migrate-manuals-frontend-code-to-government-frontend