### PR TITLE
Add social media links to topical event schema

### DIFF
--- a/dist/formats/topical_event/frontend/schema.json
+++ b/dist/formats/topical_event/frontend/schema.json
@@ -513,6 +513,45 @@
             }
           }
         },
+        "social_media_links": {
+          "description": "A set of links to social media profiles for the topical event.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "service_type",
+              "title",
+              "href"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "service_type": {
+                "type": "string",
+                "enum": [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube"
+                ]
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "start_date": {
           "type": "string",
           "format": "date-time"

--- a/dist/formats/topical_event/notification/schema.json
+++ b/dist/formats/topical_event/notification/schema.json
@@ -613,6 +613,45 @@
             }
           }
         },
+        "social_media_links": {
+          "description": "A set of links to social media profiles for the topical event.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "service_type",
+              "title",
+              "href"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "service_type": {
+                "type": "string",
+                "enum": [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube"
+                ]
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "start_date": {
           "type": "string",
           "format": "date-time"

--- a/dist/formats/topical_event/publisher_v2/schema.json
+++ b/dist/formats/topical_event/publisher_v2/schema.json
@@ -385,6 +385,45 @@
             }
           }
         },
+        "social_media_links": {
+          "description": "A set of links to social media profiles for the topical event.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "service_type",
+              "title",
+              "href"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "service_type": {
+                "type": "string",
+                "enum": [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube"
+                ]
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "start_date": {
           "type": "string",
           "format": "date-time"

--- a/formats/topical_event.jsonnet
+++ b/formats/topical_event.jsonnet
@@ -40,6 +40,45 @@
           },
           description: "A set of featured documents to display for the Topical Event.",
         },
+        social_media_links: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "service_type",
+              "title",
+              "href",
+            ],
+            properties: {
+              service_type: {
+                type: "string",
+                enum: [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube",
+                ],
+              },
+              title: {
+                type: "string",
+              },
+              href: {
+                type: "string",
+                format: "uri",
+              },
+            },
+          },
+          description: "A set of links to social media profiles for the topical event.",
+        },
       },
     },
   },


### PR DESCRIPTION
We are in the process of migrating the rendering of Topical Events out of Whitehall.

As part of this, we need to include all the relevant information in the content item.

This will allow us to store social media links, in the same way we do for organisations.

[Trello card](https://trello.com/c/DOsCLwQL)