### PR TITLE
Add body field to Topical Events

### DIFF
--- a/dist/formats/topical_event/frontend/schema.json
+++ b/dist/formats/topical_event/frontend/schema.json
@@ -478,6 +478,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "description": "The main content provided as HTML rendered from govspeak",
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/dist/formats/topical_event/notification/schema.json
+++ b/dist/formats/topical_event/notification/schema.json
@@ -578,6 +578,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "description": "The main content provided as HTML rendered from govspeak",
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/dist/formats/topical_event/publisher_v2/schema.json
+++ b/dist/formats/topical_event/publisher_v2/schema.json
@@ -353,6 +353,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "description": "The main content provided as HTML rendered from govspeak",
+          "type": "string"
+        },
         "end_date": {
           "type": "string",
           "format": "date-time"

--- a/formats/topical_event.jsonnet
+++ b/formats/topical_event.jsonnet
@@ -4,6 +4,10 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        body: {
+          description: "The main content provided as HTML rendered from govspeak",
+          type: "string"
+        },
         start_date: {
           type: "string",
           format: "date-time",


### PR DESCRIPTION
Topical Events are being migrated away from Whitehall rendering.  Therefore we need to include the body field in the content item.

[Trello card](https://trello.com/c/BRkBpgxD)