### PR TITLE
Add Topical Event image

### DIFF
--- a/dist/formats/topical_event/frontend/schema.json
+++ b/dist/formats/topical_event/frontend/schema.json
@@ -492,6 +492,17 @@
           "type": "string",
           "format": "date-time"
         },
+        "image": {
+          "properties": {
+            "alt_text": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",
           "type": "array",

--- a/dist/formats/topical_event/notification/schema.json
+++ b/dist/formats/topical_event/notification/schema.json
@@ -592,6 +592,17 @@
           "type": "string",
           "format": "date-time"
         },
+        "image": {
+          "properties": {
+            "alt_text": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",
           "type": "array",

--- a/dist/formats/topical_event/publisher_v2/schema.json
+++ b/dist/formats/topical_event/publisher_v2/schema.json
@@ -364,6 +364,17 @@
           "type": "string",
           "format": "date-time"
         },
+        "image": {
+          "properties": {
+            "alt_text": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",
           "type": "array",

--- a/formats/topical_event.jsonnet
+++ b/formats/topical_event.jsonnet
@@ -11,6 +11,17 @@
         about_page_link_text: {
           type: "string",
         },
+        image: {
+          properties: {
+           url: {
+             type: "string",
+             format: "uri",
+           },
+           alt_text: {
+             type: "string",
+           },
+          },
+        },
         start_date: {
           type: "string",
           format: "date-time",


### PR DESCRIPTION
This is needed to allow us to include the topical event's logo or image in the content item.

The page is currently rendered by Whitehall, but will be migrated to Collections, which is why this now needs to be included in the content item.

[Trello card](https://trello.com/c/uNbOV24p)