### PR TITLE
Remove `manuals-frontend` from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,6 @@ def dependentApplications = [
   'hmrc-manuals-api',
   'info-frontend',
   'licencefinder',
-  'manuals-frontend',
   'manuals-publisher',
   'publisher',
   'publishing-api',


### PR DESCRIPTION
CI is currently attempting to run a job against `manuals-frontend`, but this application was removed from CI in https://github.com/alphagov/govuk-puppet/pull/11587.

This removes that job from being run when `govuk-content-schemas` are being built.