### PR TITLE
Add emphasised organisations to topical event

### DIFF
--- a/dist/formats/topical_event/frontend/schema.json
+++ b/dist/formats/topical_event/frontend/schema.json
@@ -488,6 +488,9 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
         "end_date": {
           "type": "string",
           "format": "date-time"
@@ -574,6 +577,13 @@
           "type": "string",
           "format": "date-time"
         }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "first_published_at": {

--- a/dist/formats/topical_event/notification/schema.json
+++ b/dist/formats/topical_event/notification/schema.json
@@ -588,6 +588,9 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
         "end_date": {
           "type": "string",
           "format": "date-time"
@@ -674,6 +677,13 @@
           "type": "string",
           "format": "date-time"
         }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "first_published_at": {

--- a/dist/formats/topical_event/publisher_v2/schema.json
+++ b/dist/formats/topical_event/publisher_v2/schema.json
@@ -360,6 +360,9 @@
           "description": "The main content provided as HTML rendered from govspeak",
           "type": "string"
         },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
         "end_date": {
           "type": "string",
           "format": "date-time"
@@ -446,6 +449,13 @@
           "type": "string",
           "format": "date-time"
         }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "first_published_at": {

--- a/formats/topical_event.jsonnet
+++ b/formats/topical_event.jsonnet
@@ -30,6 +30,9 @@
           type: "string",
           format: "date-time",
         },
+        emphasised_organisations: {
+          "$ref": "#/definitions/emphasised_organisations",
+        },
         ordered_featured_documents: {
           type: "array",
           items: {


### PR DESCRIPTION
This is needed to allow us to include emphasised organisations in the
content item for a topical event.

The page is currently rendered by whitehall, but will be rendered by
collections, which is why this now needs to be included.

Trello: https://trello.com/c/iIfXqVKi/71-add-rendering-of-topical-event-organisation-names-and-logos-to-collections