### PR TITLE
Add new filter option for case_type filter in cma_cases

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -645,6 +645,7 @@
             "ca98-and-civil-cartels",
             "competition-disqualification",
             "criminal-cartels",
+            "information-and-advice-to-government",
             "markets",
             "mergers",
             "consumer-enforcement",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -746,6 +746,7 @@
             "ca98-and-civil-cartels",
             "competition-disqualification",
             "criminal-cartels",
+            "information-and-advice-to-government",
             "markets",
             "mergers",
             "consumer-enforcement",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -554,6 +554,7 @@
             "ca98-and-civil-cartels",
             "competition-disqualification",
             "criminal-cartels",
+            "information-and-advice-to-government",
             "markets",
             "mergers",
             "consumer-enforcement",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -346,6 +346,7 @@
           "ca98-and-civil-cartels",
           "competition-disqualification",
           "criminal-cartels",
+          "information-and-advice-to-government",
           "markets",
           "mergers",
           "consumer-enforcement",


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/RqdVvCSV/548-add-a-new-option-to-case-type-filter-on-cma-cases-specialist-finder)

This PR adds the "information-and-advice-to-government" option to the filter options for case_type in cma_cases.