### PR TITLE
Add title to manuals block of HMRC manuals section schema

### DIFF
--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -317,7 +317,7 @@
           "$ref": "#/definitions/hmrc_manual_child_section_groups"
         },
         "manual": {
-          "$ref": "#/definitions/manual_section_parent"
+          "$ref": "#/definitions/hmrc_manual_section_parent"
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
@@ -532,6 +532,22 @@
         }
       }
     },
+    "hmrc_manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -624,19 +640,6 @@
           "web_url": {
             "type": "string"
           }
-        }
-      }
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "required": [
-        "base_path"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -417,7 +417,7 @@
           "$ref": "#/definitions/hmrc_manual_child_section_groups"
         },
         "manual": {
-          "$ref": "#/definitions/manual_section_parent"
+          "$ref": "#/definitions/hmrc_manual_section_parent"
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
@@ -645,6 +645,22 @@
         }
       }
     },
+    "hmrc_manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -737,19 +753,6 @@
           "web_url": {
             "type": "string"
           }
-        }
-      }
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "required": [
-        "base_path"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -189,7 +189,7 @@
           "$ref": "#/definitions/hmrc_manual_child_section_groups"
         },
         "manual": {
-          "$ref": "#/definitions/manual_section_parent"
+          "$ref": "#/definitions/hmrc_manual_section_parent"
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
@@ -275,6 +275,22 @@
           "title": {
             "type": "string"
           }
+        }
+      }
+    },
+    "hmrc_manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -370,19 +386,6 @@
           "web_url": {
             "type": "string"
           }
-        }
-      }
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "required": [
-        "base_path"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
         }
       }
     },

--- a/examples/hmrc_manual_section/frontend/vatgpb2000.json
+++ b/examples/hmrc_manual_section/frontend/vatgpb2000.json
@@ -55,7 +55,8 @@
       }
     ],
     "manual": {
-      "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies"
+      "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
+      "title": "VAT Government and Public Bodies"
     },
     "organisations": [
       {

--- a/examples/hmrc_manual_section/publisher_v2/hmrc_manual_section.json
+++ b/examples/hmrc_manual_section/publisher_v2/hmrc_manual_section.json
@@ -55,7 +55,8 @@
       }
     ],
     "manual": {
-      "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies"
+      "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
+      "title": "VAT Government and Public Bodies"
     },
     "organisations": [
       {

--- a/formats/hmrc_manual_section.jsonnet
+++ b/formats/hmrc_manual_section.jsonnet
@@ -19,7 +19,7 @@
           "$ref": "#/definitions/body",
         },
         manual: {
-          "$ref": "#/definitions/manual_section_parent",
+          "$ref": "#/definitions/hmrc_manual_section_parent",
         },
         organisations: {
           "$ref": "#/definitions/manual_organisations",

--- a/formats/shared/definitions/hmrc_manual.jsonnet
+++ b/formats/shared/definitions/hmrc_manual.jsonnet
@@ -95,4 +95,20 @@
       },
     },
   },
+  hmrc_manual_section_parent: {
+    description: "The parent manual for a manual section",
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "base_path"
+    ],
+    properties: {
+      base_path: {
+        "$ref": "#/definitions/absolute_path",
+      },
+      title: {
+        type: "string",
+      }
+    },
+  },
 }


### PR DESCRIPTION
Add manual title to HMRC manuals section schema, needed to render HMRC manuals more efficiently now they've been moved to government-frontend.

Note that this field will be required when tasks have been run to add titles to all existing and new documents.

https://trello.com/c/NToovfjr/1349-add-parent-manuals-title-to-the-hmrc-section-content-item