### PR TITLE
Make title required for manual block of hmrc manual section.

### DIFF
--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -536,7 +536,8 @@
       "description": "The parent manual for a manual section",
       "type": "object",
       "required": [
-        "base_path"
+        "base_path",
+        "title"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -649,7 +649,8 @@
       "description": "The parent manual for a manual section",
       "type": "object",
       "required": [
-        "base_path"
+        "base_path",
+        "title"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -282,7 +282,8 @@
       "description": "The parent manual for a manual section",
       "type": "object",
       "required": [
-        "base_path"
+        "base_path",
+        "title"
       ],
       "additionalProperties": false,
       "properties": {

--- a/formats/shared/definitions/hmrc_manual.jsonnet
+++ b/formats/shared/definitions/hmrc_manual.jsonnet
@@ -100,7 +100,8 @@
     type: "object",
     additionalProperties: false,
     required: [
-      "base_path"
+      "base_path",
+      "title",
     ],
     properties: {
       base_path: {


### PR DESCRIPTION
Now that all HMRC Manual sections have title blocks (except for a small number that are broken for other reasons), and newly-made ones will have the title block, we can make this required in the schema so that the rendering app (government-frontend) can rely on it.

https://trello.com/c/NToovfjr/1349-add-parent-manuals-title-to-the-hmrc-section-content-item