### PR TITLE
Add format for world location news

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -463,46 +463,7 @@
           }
         },
         "ordered_featured_documents": {
-          "description": "A set of featured documents to display for the organisation. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "href",
-              "image",
-              "summary",
-              "public_updated_at",
-              "document_type"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "document_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "public_updated_at": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "summary": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/ordered_featured_documents"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
@@ -973,6 +934,48 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_documents": {
+      "description": "A set of featured documents to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "image",
+          "summary",
+          "public_updated_at",
+          "document_type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "document_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "public_updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "ordered_featured_links": {
       "description": "A set of featured links to display.",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -505,24 +505,7 @@
           }
         },
         "ordered_featured_links": {
-          "description": "A set of featured links to display for the organisation.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "href": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/ordered_featured_links"
         },
         "ordered_promotional_features": {
           "description": "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
@@ -990,6 +973,26 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_links": {
+      "description": "A set of featured links to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -661,24 +661,7 @@
           }
         },
         "ordered_featured_links": {
-          "description": "A set of featured links to display for the organisation.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "href": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/ordered_featured_links"
         },
         "ordered_promotional_features": {
           "description": "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
@@ -1159,6 +1142,26 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_links": {
+      "description": "A set of featured links to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -619,46 +619,7 @@
           }
         },
         "ordered_featured_documents": {
-          "description": "A set of featured documents to display for the organisation. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "href",
-              "image",
-              "summary",
-              "public_updated_at",
-              "document_type"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "document_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "public_updated_at": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "summary": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/ordered_featured_documents"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
@@ -1142,6 +1103,48 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_documents": {
+      "description": "A set of featured documents to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "image",
+          "summary",
+          "public_updated_at",
+          "document_type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "document_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "public_updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "ordered_featured_links": {
       "description": "A set of featured links to display.",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -335,46 +335,7 @@
           }
         },
         "ordered_featured_documents": {
-          "description": "A set of featured documents to display for the organisation. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "href",
-              "image",
-              "summary",
-              "public_updated_at",
-              "document_type"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "document_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "public_updated_at": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "summary": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/ordered_featured_documents"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
@@ -719,6 +680,48 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_documents": {
+      "description": "A set of featured documents to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "image",
+          "summary",
+          "public_updated_at",
+          "document_type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "document_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "public_updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "ordered_featured_links": {
       "description": "A set of featured links to display.",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -377,24 +377,7 @@
           }
         },
         "ordered_featured_links": {
-          "description": "A set of featured links to display for the organisation.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "href": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/ordered_featured_links"
         },
         "ordered_promotional_features": {
           "description": "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
@@ -736,6 +719,26 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_links": {
+      "description": "A set of featured links to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -477,12 +477,16 @@
     "details": {
       "type": "object",
       "required": [
-        "ordered_featured_links"
+        "ordered_featured_links",
+        "mission_statement"
       ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "mission_statement": {
+          "type": "string"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"

--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -478,7 +478,8 @@
       "type": "object",
       "required": [
         "ordered_featured_links",
-        "mission_statement"
+        "mission_statement",
+        "ordered_featured_documents"
       ],
       "additionalProperties": false,
       "properties": {
@@ -487,6 +488,9 @@
         },
         "mission_statement": {
           "type": "string"
+        },
+        "ordered_featured_documents": {
+          "$ref": "#/definitions/ordered_featured_documents"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
@@ -635,6 +639,48 @@
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -705,6 +751,48 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_documents": {
+      "description": "A set of featured documents to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "image",
+          "summary",
+          "public_updated_at",
+          "document_type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "document_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "public_updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "ordered_featured_links": {
       "description": "A set of featured links to display.",

--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -1,0 +1,808 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "base_path",
+    "content_id",
+    "description",
+    "details",
+    "document_type",
+    "links",
+    "locale",
+    "public_updated_at",
+    "schema_name",
+    "title",
+    "updated_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "about",
+        "about_our_services",
+        "accessible_documents_policy",
+        "access_and_opening",
+        "ambassador_role",
+        "answer",
+        "asylum_support_decision",
+        "authored_article",
+        "board_member_role",
+        "business_finance_support_scheme",
+        "calculator",
+        "calendar",
+        "case_study",
+        "chief_professional_officer_role",
+        "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
+        "closed_consultation",
+        "cma_case",
+        "coming_soon",
+        "complaints_procedure",
+        "completed_transaction",
+        "consultation",
+        "consultation_outcome",
+        "contact",
+        "coronavirus_landing_page",
+        "corporate_report",
+        "correspondence",
+        "countryside_stewardship_grant",
+        "decision",
+        "deputy_head_of_mission_role",
+        "detailed_guidance",
+        "detailed_guide",
+        "dfid_research_output",
+        "document_collection",
+        "drcf_digital_markets_research",
+        "drug_safety_update",
+        "email_alert_signup",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "equality_and_diversity",
+        "esi_fund",
+        "export_health_certificate",
+        "external_content",
+        "facet",
+        "facet_group",
+        "facet_value",
+        "fatality_notice",
+        "field_of_operation",
+        "finder",
+        "finder_email_signup",
+        "flood_and_coastal_erosion_risk_management_research_report",
+        "foi_release",
+        "form",
+        "get_involved",
+        "gone",
+        "government",
+        "government_response",
+        "governor_role",
+        "guidance",
+        "guide",
+        "help_page",
+        "high_commissioner_role",
+        "history",
+        "hmrc_manual",
+        "hmrc_manual_section",
+        "homepage",
+        "html_publication",
+        "impact_assessment",
+        "imported",
+        "independent_report",
+        "international_development_fund",
+        "international_treaty",
+        "knowledge_alpha",
+        "licence",
+        "license_finder",
+        "local_transaction",
+        "maib_report",
+        "mainstream_browse_page",
+        "manual",
+        "manual_section",
+        "map",
+        "marine_notice",
+        "media_enquiries",
+        "medical_safety_alert",
+        "membership",
+        "military_role",
+        "ministerial_role",
+        "ministers_index",
+        "modern_slavery_statement",
+        "national",
+        "national_statistics",
+        "national_statistics_announcement",
+        "need",
+        "news_article",
+        "news_story",
+        "notice",
+        "official",
+        "official_statistics",
+        "official_statistics_announcement",
+        "oim_project",
+        "open_consultation",
+        "oral_statement",
+        "organisation",
+        "our_energy_use",
+        "our_governance",
+        "person",
+        "personal_information_charter",
+        "petitions_and_campaigns",
+        "place",
+        "placeholder",
+        "placeholder_ministerial_role",
+        "placeholder_organisation",
+        "placeholder_person",
+        "placeholder_policy_area",
+        "placeholder_topical_event",
+        "placeholder_world_location",
+        "placeholder_world_location_news_page",
+        "placeholder_worldwide_organisation",
+        "policy_area",
+        "policy_paper",
+        "press_release",
+        "procurement",
+        "product_safety_alert_report_recall",
+        "promotional",
+        "protected_food_drink_name",
+        "publication_scheme",
+        "raib_report",
+        "recruitment",
+        "redirect",
+        "regulation",
+        "research",
+        "research_for_development_output",
+        "residential_property_tribunal_decision",
+        "role_appointment",
+        "search",
+        "service_manual_guide",
+        "service_manual_homepage",
+        "service_manual_service_standard",
+        "service_manual_service_toolkit",
+        "service_manual_topic",
+        "service_sign_in",
+        "service_standard_report",
+        "services_and_information",
+        "simple_smart_answer",
+        "smart_answer",
+        "social_media_use",
+        "special_representative_role",
+        "special_route",
+        "speech",
+        "staff_update",
+        "standard",
+        "statistical_data_set",
+        "statistics",
+        "statistics_announcement",
+        "statutory_guidance",
+        "statutory_instrument",
+        "step_by_step_nav",
+        "take_part",
+        "tax_tribunal_decision",
+        "taxon",
+        "terms_of_reference",
+        "topic",
+        "topical_event",
+        "topical_event_about_page",
+        "traffic_commissioner_regulatory_decision",
+        "traffic_commissioner_role",
+        "transaction",
+        "transparency",
+        "travel_advice",
+        "travel_advice_index",
+        "unpublishing",
+        "uk_market_conformity_assessment_body",
+        "utaac_decision",
+        "vanish",
+        "welsh_language_scheme",
+        "working_group",
+        "world_location",
+        "world_location_news_article",
+        "world_news_story",
+        "worldwide_office_staff_role",
+        "worldwide_organisation",
+        "written_statement"
+      ]
+    },
+    "first_published_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/first_published_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "facet_values": {
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "level_one_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ministers": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "part_of_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "related_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "role_appointments": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "secondary_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topic_taxonomy_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "public_updated_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app"
+    },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "world_location_news"
+      ]
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "frontend_links_with_base_path": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links_with_base_path"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "rendering_app": {
+      "description": "The application that renders this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections",
+        "content-store",
+        "email-alert-frontend",
+        "email-campaign-frontend",
+        "feedback",
+        "finder-frontend",
+        "frontend",
+        "government-frontend",
+        "info-frontend",
+        "licencefinder",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "search-api",
+        "service-manual-frontend",
+        "smartanswers",
+        "spotlight",
+        "static",
+        "tariff",
+        "whitehall-admin",
+        "whitehall-frontend"
+      ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
+    },
+    "title": {
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -476,10 +476,16 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "ordered_featured_links"
+      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "ordered_featured_links": {
+          "$ref": "#/definitions/ordered_featured_links"
         }
       }
     },
@@ -695,6 +701,26 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_links": {
+      "description": "A set of featured links to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -578,7 +578,8 @@
       "type": "object",
       "required": [
         "ordered_featured_links",
-        "mission_statement"
+        "mission_statement",
+        "ordered_featured_documents"
       ],
       "additionalProperties": false,
       "properties": {
@@ -587,6 +588,9 @@
         },
         "mission_statement": {
           "type": "string"
+        },
+        "ordered_featured_documents": {
+          "$ref": "#/definitions/ordered_featured_documents"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
@@ -748,6 +752,48 @@
       },
       "uniqueItems": true
     },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -818,6 +864,48 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_documents": {
+      "description": "A set of featured documents to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "image",
+          "summary",
+          "public_updated_at",
+          "document_type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "document_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "public_updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "ordered_featured_links": {
       "description": "A set of featured links to display.",

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -577,12 +577,16 @@
     "details": {
       "type": "object",
       "required": [
-        "ordered_featured_links"
+        "ordered_featured_links",
+        "mission_statement"
       ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "mission_statement": {
+          "type": "string"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -576,10 +576,16 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "ordered_featured_links"
+      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "ordered_featured_links": {
+          "$ref": "#/definitions/ordered_featured_links"
         }
       }
     },
@@ -808,6 +814,26 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_links": {
+      "description": "A set of featured links to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -1,0 +1,949 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "analytics_identifier",
+    "base_path",
+    "content_id",
+    "description",
+    "details",
+    "document_type",
+    "email_document_supertype",
+    "expanded_links",
+    "first_published_at",
+    "government_document_supertype",
+    "govuk_request_id",
+    "links",
+    "locale",
+    "payload_version",
+    "phase",
+    "public_updated_at",
+    "publishing_app",
+    "redirects",
+    "rendering_app",
+    "routes",
+    "schema_name",
+    "title",
+    "update_type"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "content_purpose_document_supertype": {
+      "description": "DEPRECATED. Use `content_purpose_subgroup`.",
+      "type": "string"
+    },
+    "content_purpose_subgroup": {
+      "description": "Document subgroup grouping documents by purpose. Narrows down the purpose defined in content_purpose_supergroup.",
+      "type": "string"
+    },
+    "content_purpose_supergroup": {
+      "description": "Document supergroup grouping documents by a purpose",
+      "type": "string"
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "about",
+        "about_our_services",
+        "accessible_documents_policy",
+        "access_and_opening",
+        "ambassador_role",
+        "answer",
+        "asylum_support_decision",
+        "authored_article",
+        "board_member_role",
+        "business_finance_support_scheme",
+        "calculator",
+        "calendar",
+        "case_study",
+        "chief_professional_officer_role",
+        "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
+        "closed_consultation",
+        "cma_case",
+        "coming_soon",
+        "complaints_procedure",
+        "completed_transaction",
+        "consultation",
+        "consultation_outcome",
+        "contact",
+        "coronavirus_landing_page",
+        "corporate_report",
+        "correspondence",
+        "countryside_stewardship_grant",
+        "decision",
+        "deputy_head_of_mission_role",
+        "detailed_guidance",
+        "detailed_guide",
+        "dfid_research_output",
+        "document_collection",
+        "drcf_digital_markets_research",
+        "drug_safety_update",
+        "email_alert_signup",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "equality_and_diversity",
+        "esi_fund",
+        "export_health_certificate",
+        "external_content",
+        "facet",
+        "facet_group",
+        "facet_value",
+        "fatality_notice",
+        "field_of_operation",
+        "finder",
+        "finder_email_signup",
+        "flood_and_coastal_erosion_risk_management_research_report",
+        "foi_release",
+        "form",
+        "get_involved",
+        "gone",
+        "government",
+        "government_response",
+        "governor_role",
+        "guidance",
+        "guide",
+        "help_page",
+        "high_commissioner_role",
+        "history",
+        "hmrc_manual",
+        "hmrc_manual_section",
+        "homepage",
+        "html_publication",
+        "impact_assessment",
+        "imported",
+        "independent_report",
+        "international_development_fund",
+        "international_treaty",
+        "knowledge_alpha",
+        "licence",
+        "license_finder",
+        "local_transaction",
+        "maib_report",
+        "mainstream_browse_page",
+        "manual",
+        "manual_section",
+        "map",
+        "marine_notice",
+        "media_enquiries",
+        "medical_safety_alert",
+        "membership",
+        "military_role",
+        "ministerial_role",
+        "ministers_index",
+        "modern_slavery_statement",
+        "national",
+        "national_statistics",
+        "national_statistics_announcement",
+        "need",
+        "news_article",
+        "news_story",
+        "notice",
+        "official",
+        "official_statistics",
+        "official_statistics_announcement",
+        "oim_project",
+        "open_consultation",
+        "oral_statement",
+        "organisation",
+        "our_energy_use",
+        "our_governance",
+        "person",
+        "personal_information_charter",
+        "petitions_and_campaigns",
+        "place",
+        "placeholder",
+        "placeholder_ministerial_role",
+        "placeholder_organisation",
+        "placeholder_person",
+        "placeholder_policy_area",
+        "placeholder_topical_event",
+        "placeholder_world_location",
+        "placeholder_world_location_news_page",
+        "placeholder_worldwide_organisation",
+        "policy_area",
+        "policy_paper",
+        "press_release",
+        "procurement",
+        "product_safety_alert_report_recall",
+        "promotional",
+        "protected_food_drink_name",
+        "publication_scheme",
+        "raib_report",
+        "recruitment",
+        "redirect",
+        "regulation",
+        "research",
+        "research_for_development_output",
+        "residential_property_tribunal_decision",
+        "role_appointment",
+        "search",
+        "service_manual_guide",
+        "service_manual_homepage",
+        "service_manual_service_standard",
+        "service_manual_service_toolkit",
+        "service_manual_topic",
+        "service_sign_in",
+        "service_standard_report",
+        "services_and_information",
+        "simple_smart_answer",
+        "smart_answer",
+        "social_media_use",
+        "special_representative_role",
+        "special_route",
+        "speech",
+        "staff_update",
+        "standard",
+        "statistical_data_set",
+        "statistics",
+        "statistics_announcement",
+        "statutory_guidance",
+        "statutory_instrument",
+        "step_by_step_nav",
+        "take_part",
+        "tax_tribunal_decision",
+        "taxon",
+        "terms_of_reference",
+        "topic",
+        "topical_event",
+        "topical_event_about_page",
+        "traffic_commissioner_regulatory_decision",
+        "traffic_commissioner_role",
+        "transaction",
+        "transparency",
+        "travel_advice",
+        "travel_advice_index",
+        "unpublishing",
+        "uk_market_conformity_assessment_body",
+        "utaac_decision",
+        "vanish",
+        "welsh_language_scheme",
+        "working_group",
+        "world_location",
+        "world_location_news_article",
+        "world_news_story",
+        "worldwide_office_staff_role",
+        "worldwide_organisation",
+        "written_statement"
+      ]
+    },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "expanded_links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "facet_values": {
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "level_one_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ministers": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "part_of_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "related_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "role_appointments": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "secondary_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topic_taxonomy_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        }
+      }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "$ref": "#/definitions/govuk_request_id"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "facet_values": {
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "payload_version": {
+      "$ref": "#/definitions/payload_version"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app"
+    },
+    "routes": {
+      "$ref": "#/definitions/routes"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "world_location_news"
+      ]
+    },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "user_need_document_supertype": {
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "frontend_links_with_base_path": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links_with_base_path"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "rendering_app": {
+      "description": "The application that renders this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections",
+        "content-store",
+        "email-alert-frontend",
+        "email-campaign-frontend",
+        "feedback",
+        "finder-frontend",
+        "frontend",
+        "government-frontend",
+        "info-frontend",
+        "licencefinder",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "search-api",
+        "service-manual-frontend",
+        "smartanswers",
+        "spotlight",
+        "static",
+        "tariff",
+        "whitehall-admin",
+        "whitehall-frontend"
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/world_location_news/publisher_v2/links.json
+++ b/dist/formats/world_location_news/publisher_v2/links.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "facet_groups": {
+          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "facet_values": {
+          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "previous_version": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/dist/formats/world_location_news/publisher_v2/schema.json
@@ -353,12 +353,16 @@
       "type": "object",
       "required": [
         "ordered_featured_links",
-        "mission_statement"
+        "mission_statement",
+        "ordered_featured_documents"
       ],
       "additionalProperties": false,
       "properties": {
         "mission_statement": {
           "type": "string"
+        },
+        "ordered_featured_documents": {
+          "$ref": "#/definitions/ordered_featured_documents"
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
@@ -380,6 +384,48 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",
@@ -451,6 +497,48 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_documents": {
+      "description": "A set of featured documents to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "image",
+          "summary",
+          "public_updated_at",
+          "document_type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "document_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "public_updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "ordered_featured_links": {
       "description": "A set of featured links to display.",

--- a/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/dist/formats/world_location_news/publisher_v2/schema.json
@@ -1,0 +1,555 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "base_path",
+    "details",
+    "document_type",
+    "publishing_app",
+    "rendering_app",
+    "routes",
+    "schema_name",
+    "title"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "about",
+        "about_our_services",
+        "accessible_documents_policy",
+        "access_and_opening",
+        "ambassador_role",
+        "answer",
+        "asylum_support_decision",
+        "authored_article",
+        "board_member_role",
+        "business_finance_support_scheme",
+        "calculator",
+        "calendar",
+        "case_study",
+        "chief_professional_officer_role",
+        "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
+        "closed_consultation",
+        "cma_case",
+        "coming_soon",
+        "complaints_procedure",
+        "completed_transaction",
+        "consultation",
+        "consultation_outcome",
+        "contact",
+        "coronavirus_landing_page",
+        "corporate_report",
+        "correspondence",
+        "countryside_stewardship_grant",
+        "decision",
+        "deputy_head_of_mission_role",
+        "detailed_guidance",
+        "detailed_guide",
+        "dfid_research_output",
+        "document_collection",
+        "drcf_digital_markets_research",
+        "drug_safety_update",
+        "email_alert_signup",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "equality_and_diversity",
+        "esi_fund",
+        "export_health_certificate",
+        "external_content",
+        "facet",
+        "facet_group",
+        "facet_value",
+        "fatality_notice",
+        "field_of_operation",
+        "finder",
+        "finder_email_signup",
+        "flood_and_coastal_erosion_risk_management_research_report",
+        "foi_release",
+        "form",
+        "get_involved",
+        "gone",
+        "government",
+        "government_response",
+        "governor_role",
+        "guidance",
+        "guide",
+        "help_page",
+        "high_commissioner_role",
+        "history",
+        "hmrc_manual",
+        "hmrc_manual_section",
+        "homepage",
+        "html_publication",
+        "impact_assessment",
+        "imported",
+        "independent_report",
+        "international_development_fund",
+        "international_treaty",
+        "knowledge_alpha",
+        "licence",
+        "license_finder",
+        "local_transaction",
+        "maib_report",
+        "mainstream_browse_page",
+        "manual",
+        "manual_section",
+        "map",
+        "marine_notice",
+        "media_enquiries",
+        "medical_safety_alert",
+        "membership",
+        "military_role",
+        "ministerial_role",
+        "ministers_index",
+        "modern_slavery_statement",
+        "national",
+        "national_statistics",
+        "national_statistics_announcement",
+        "need",
+        "news_article",
+        "news_story",
+        "notice",
+        "official",
+        "official_statistics",
+        "official_statistics_announcement",
+        "oim_project",
+        "open_consultation",
+        "oral_statement",
+        "organisation",
+        "our_energy_use",
+        "our_governance",
+        "person",
+        "personal_information_charter",
+        "petitions_and_campaigns",
+        "place",
+        "placeholder",
+        "placeholder_ministerial_role",
+        "placeholder_organisation",
+        "placeholder_person",
+        "placeholder_policy_area",
+        "placeholder_topical_event",
+        "placeholder_world_location",
+        "placeholder_world_location_news_page",
+        "placeholder_worldwide_organisation",
+        "policy_area",
+        "policy_paper",
+        "press_release",
+        "procurement",
+        "product_safety_alert_report_recall",
+        "promotional",
+        "protected_food_drink_name",
+        "publication_scheme",
+        "raib_report",
+        "recruitment",
+        "redirect",
+        "regulation",
+        "research",
+        "research_for_development_output",
+        "residential_property_tribunal_decision",
+        "role_appointment",
+        "search",
+        "service_manual_guide",
+        "service_manual_homepage",
+        "service_manual_service_standard",
+        "service_manual_service_toolkit",
+        "service_manual_topic",
+        "service_sign_in",
+        "service_standard_report",
+        "services_and_information",
+        "simple_smart_answer",
+        "smart_answer",
+        "social_media_use",
+        "special_representative_role",
+        "special_route",
+        "speech",
+        "staff_update",
+        "standard",
+        "statistical_data_set",
+        "statistics",
+        "statistics_announcement",
+        "statutory_guidance",
+        "statutory_instrument",
+        "step_by_step_nav",
+        "take_part",
+        "tax_tribunal_decision",
+        "taxon",
+        "terms_of_reference",
+        "topic",
+        "topical_event",
+        "topical_event_about_page",
+        "traffic_commissioner_regulatory_decision",
+        "traffic_commissioner_role",
+        "transaction",
+        "transparency",
+        "travel_advice",
+        "travel_advice_index",
+        "unpublishing",
+        "uk_market_conformity_assessment_body",
+        "utaac_decision",
+        "vanish",
+        "welsh_language_scheme",
+        "working_group",
+        "world_location",
+        "world_location_news_article",
+        "world_news_story",
+        "worldwide_office_staff_role",
+        "worldwide_organisation",
+        "written_statement"
+      ]
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app"
+    },
+    "routes": {
+      "$ref": "#/definitions/routes"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "world_location_news"
+      ]
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app": {
+      "description": "The application that renders this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections",
+        "content-store",
+        "email-alert-frontend",
+        "email-campaign-frontend",
+        "feedback",
+        "finder-frontend",
+        "frontend",
+        "government-frontend",
+        "info-frontend",
+        "licencefinder",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "search-api",
+        "service-manual-frontend",
+        "smartanswers",
+        "spotlight",
+        "static",
+        "tariff",
+        "whitehall-admin",
+        "whitehall-frontend"
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    }
+  }
+}

--- a/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/dist/formats/world_location_news/publisher_v2/schema.json
@@ -351,8 +351,14 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "ordered_featured_links"
+      ],
       "additionalProperties": false,
       "properties": {
+        "ordered_featured_links": {
+          "$ref": "#/definitions/ordered_featured_links"
+        }
       }
     },
     "first_published_at": {
@@ -441,6 +447,26 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "ordered_featured_links": {
+      "description": "A set of featured links to display.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/dist/formats/world_location_news/publisher_v2/schema.json
@@ -352,10 +352,14 @@
     "details": {
       "type": "object",
       "required": [
-        "ordered_featured_links"
+        "ordered_featured_links",
+        "mission_statement"
       ],
       "additionalProperties": false,
       "properties": {
+        "mission_statement": {
+          "type": "string"
+        },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
         }

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -96,24 +96,7 @@
           description: "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
         },
         ordered_featured_links: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "title",
-              "href",
-            ],
-            properties: {
-              title: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-            },
-          },
-          description: "A set of featured links to display for the organisation.",
+           "$ref": "#/definitions/ordered_featured_links",
         },
         ordered_featured_documents: {
           type: "array",

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -99,46 +99,7 @@
            "$ref": "#/definitions/ordered_featured_links",
         },
         ordered_featured_documents: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "title",
-              "href",
-              "image",
-              "summary",
-              "public_updated_at",
-              "document_type",
-            ],
-            properties: {
-              title: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              summary: {
-                type: "string",
-              },
-              public_updated_at: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              document_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A set of featured documents to display for the organisation. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/ordered_featured_documents",
         },
         ordered_promotional_features: {
           type: "array",

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -322,4 +322,46 @@
     },
     description: "A set of featured links to display.",
   },
+  ordered_featured_documents: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+        "image",
+        "summary",
+        "public_updated_at",
+        "document_type",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+        image: {
+          "$ref": "#/definitions/image",
+        },
+        summary: {
+          type: "string",
+        },
+        public_updated_at: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        document_type: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+      },
+    },
+    description: "A set of featured documents to display.",
+  }
 }

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -301,5 +301,25 @@
       },
     },
     description: "A list of URLs and titles for a brexit no deal notice.",
-  }
+  },
+  ordered_featured_links: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+      },
+    },
+    description: "A set of featured links to display.",
+  },
 }

--- a/formats/world_location_news.jsonnet
+++ b/formats/world_location_news.jsonnet
@@ -1,0 +1,10 @@
+(import "shared/default_format.jsonnet") + {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
+    details: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+      },
+    },
+  },
+}

--- a/formats/world_location_news.jsonnet
+++ b/formats/world_location_news.jsonnet
@@ -3,14 +3,21 @@
     details: {
       type: "object",
       additionalProperties: false,
-      required: ["ordered_featured_links", "mission_statement"],
+      required: [
+         "ordered_featured_links",
+         "mission_statement",
+         "ordered_featured_documents"
+       ],
       properties: {
         ordered_featured_links: {
           "$ref": "#/definitions/ordered_featured_links",
         },
         mission_statement: {
           type: "string"
-        }
+        },
+        ordered_featured_documents: {
+          "$ref": "#/definitions/ordered_featured_documents",
+        },
       },
     },
   },

--- a/formats/world_location_news.jsonnet
+++ b/formats/world_location_news.jsonnet
@@ -3,7 +3,11 @@
     details: {
       type: "object",
       additionalProperties: false,
+      required: ["ordered_featured_links"],
       properties: {
+        ordered_featured_links: {
+          "$ref": "#/definitions/ordered_featured_links",
+        },
       },
     },
   },

--- a/formats/world_location_news.jsonnet
+++ b/formats/world_location_news.jsonnet
@@ -3,11 +3,14 @@
     details: {
       type: "object",
       additionalProperties: false,
-      required: ["ordered_featured_links"],
+      required: ["ordered_featured_links", "mission_statement"],
       properties: {
         ordered_featured_links: {
           "$ref": "#/definitions/ordered_featured_links",
         },
+        mission_statement: {
+          type: "string"
+        }
       },
     },
   },


### PR DESCRIPTION
This was previously using a placeholder schema, but this PR introduces a schema for world location news.

There are several elements that are shared with organisations, which have been moved to the shared whitehall definitions so that both schemas can use the same definitions.

I have made the elements of the details hash mandatory. This doesn't seem to be a standard approach across our schemas, but making them mandatory does seem to be more helpful in a schema, guaranteeing the presence of these fields. This makes sense for the featured links and featured documents as they are always present (although can be empty, which is allowable by the schema). Mission statement can in theory be nil (they are nullable in the database and there are two world locations for which this is the case, but they are old) although I think the Whitehall UI currently always creates a mission statement, but it can be an empty string. In the whitehall work I've defaulted it to an empty string for these cases.

[Trello](https://trello.com/c/FUNRgTWI/168-get-world-news-content-into-content-item)