### PR TITLE
Remove facet groups and facet values

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/calendar/publisher_v2/links.json
+++ b/dist/formats/calendar/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -213,14 +205,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -70,14 +70,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -88,14 +88,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -217,14 +209,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -205,14 +197,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coronavirus_landing_page/publisher_v2/links.json
+++ b/dist/formats/coronavirus_landing_page/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -91,14 +91,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -109,14 +109,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -229,14 +221,6 @@
       "additionalProperties": false,
       "properties": {
         "corporate_information_pages": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -13,14 +13,6 @@
         "corporate_information_pages": {
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -68,14 +68,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -86,14 +86,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -213,14 +205,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -70,14 +70,6 @@
         "documents": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -88,14 +88,6 @@
         "documents": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -216,14 +208,6 @@
       "additionalProperties": false,
       "properties": {
         "documents": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -13,14 +13,6 @@
         "documents": {
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/facet/frontend/schema.json
+++ b/dist/formats/facet/frontend/schema.json
@@ -69,7 +69,7 @@
         },
         "facet_values": {
           "description": "Possible facet_values to show for non-dynamic select facets. All values are shown regardless of the search.",
-          "$ref": "#/definitions/frontend_links"
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",

--- a/dist/formats/facet/notification/schema.json
+++ b/dist/formats/facet/notification/schema.json
@@ -87,7 +87,7 @@
         },
         "facet_values": {
           "description": "Possible facet_values to show for non-dynamic select facets. All values are shown regardless of the search.",
-          "$ref": "#/definitions/frontend_links"
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",

--- a/dist/formats/facet_value/frontend/schema.json
+++ b/dist/formats/facet_value/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/facet_value/notification/schema.json
+++ b/dist/formats/facet_value/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/facet_value/publisher_v2/links.json
+++ b/dist/formats/facet_value/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "field_of_operation": {
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "field_of_operation": {
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
@@ -211,14 +203,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "field_of_operation": {
           "$ref": "#/definitions/guid_list",
           "maxItems": 1,

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "field_of_operation": {
           "$ref": "#/definitions/guid_list",
           "maxItems": 1

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -75,14 +75,6 @@
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -93,14 +93,6 @@
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -220,14 +212,6 @@
           "description": "The facet_group this finder uses to define available filters.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
         },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -21,14 +21,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -201,14 +193,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -249,14 +249,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -267,14 +267,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -381,14 +373,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -249,14 +249,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -267,14 +267,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -381,14 +373,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/get_involved/frontend/schema.json
+++ b/dist/formats/get_involved/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/get_involved/notification/schema.json
+++ b/dist/formats/get_involved/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/get_involved/publisher_v2/links.json
+++ b/dist/formats/get_involved/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/government/frontend/schema.json
+++ b/dist/formats/government/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/government/notification/schema.json
+++ b/dist/formats/government/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/government/publisher_v2/links.json
+++ b/dist/formats/government/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/history/frontend/schema.json
+++ b/dist/formats/history/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/history/notification/schema.json
+++ b/dist/formats/history/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/history/publisher_v2/links.json
+++ b/dist/formats/history/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -201,14 +193,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -72,14 +72,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -90,14 +90,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -219,14 +211,6 @@
           "description": "The top-level browse page which is active",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
         },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -15,14 +15,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -66,14 +66,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -84,14 +84,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -201,14 +193,6 @@
       "additionalProperties": false,
       "properties": {
         "available_translations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -13,14 +13,6 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -66,14 +66,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -84,14 +84,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -201,14 +193,6 @@
       "additionalProperties": false,
       "properties": {
         "available_translations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -13,14 +13,6 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/ministers_index/frontend/schema.json
+++ b/dist/formats/ministers_index/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/ministers_index/notification/schema.json
+++ b/dist/formats/ministers_index/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/ministers_index/publisher_v2/links.json
+++ b/dist/formats/ministers_index/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -70,14 +70,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -88,14 +88,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -230,14 +222,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -255,14 +247,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisation/publisher_v2/links.json
+++ b/dist/formats/organisation/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/person/publisher_v2/links.json
+++ b/dist/formats/person/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -249,14 +249,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations. Deprecated in favour of ordered_featured_policies.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -267,14 +267,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations. Deprecated in favour of ordered_featured_policies.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -385,14 +377,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations. Deprecated in favour of ordered_featured_policies.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -87,14 +87,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -105,14 +105,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -240,14 +232,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -79,14 +79,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -97,14 +97,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -220,14 +212,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role/publisher_v2/links.json
+++ b/dist/formats/role/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -207,14 +199,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role_appointment/publisher_v2/links.json
+++ b/dist/formats/role_appointment/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -71,14 +71,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -89,14 +89,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -209,14 +201,6 @@
       "properties": {
         "content_owners": {
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -14,14 +14,6 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -71,14 +71,6 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -89,14 +89,6 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -205,14 +197,6 @@
       "properties": {
         "email_alert_signup": {
           "description": "References an email alert signup page for the service standard",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -14,14 +14,6 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -75,14 +75,6 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -93,14 +93,6 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -217,14 +209,6 @@
         },
         "email_alert_signup": {
           "description": "References an email alert signup page for this topic",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -18,14 +18,6 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/guid_list"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/dist/formats/service_sign_in/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/smart_answer/frontend/schema.json
+++ b/dist/formats/smart_answer/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/smart_answer/notification/schema.json
+++ b/dist/formats/smart_answer/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/smart_answer/publisher_v2/links.json
+++ b/dist/formats/smart_answer/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -252,14 +252,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -270,14 +270,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -384,14 +376,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -95,14 +95,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "The finder for this specialist document.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -113,14 +113,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "The finder for this specialist document.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -227,14 +219,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "The finder for this specialist document.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -70,14 +70,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -88,14 +88,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -229,14 +221,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -203,14 +195,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -71,14 +71,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -89,14 +89,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -202,14 +194,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -71,14 +71,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -89,14 +89,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -217,14 +209,6 @@
       "properties": {
         "associated_taxons": {
           "description": "A list of associated taxons whose children should be included as children of this taxon",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -203,14 +195,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event/frontend/schema.json
+++ b/dist/formats/topical_event/frontend/schema.json
@@ -249,14 +249,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topical_event/notification/schema.json
+++ b/dist/formats/topical_event/notification/schema.json
@@ -267,14 +267,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -381,14 +373,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event/publisher_v2/links.json
+++ b/dist/formats/topical_event/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -205,14 +197,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -202,14 +194,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -199,14 +191,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -203,14 +195,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -67,14 +67,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -85,14 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -213,14 +205,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/examples/guide/frontend/guide-with-facet-groups.json
+++ b/examples/guide/frontend/guide-with-facet-groups.json
@@ -15,34 +15,6 @@
   "withdrawn_notice": {
   },
   "links": {
-    "facet_groups": [
-      {
-        "content_id": "52435175-82ed-4a04-adef-74c0199d0f46",
-        "title": "Find EU Exit guidance business",
-        "schema_name": "facet_group",
-        "locale": "en",
-        "details": {
-          "name": "Find EU Exit guidance business",
-          "description": "Facets for use with content relating to EU Exit business guidance."
-        },
-        "links": {
-        }
-      }
-    ],
-    "facet_values": [
-      {
-        "content_id": "ec2c2efd-4cf1-4a5a-94fb-c905d2f3924b",
-        "title": "Tourism",
-        "schema_name": "facet_value",
-        "locale": "en",
-        "details": {
-          "label": "Tourism",
-          "value": "tourism"
-        },
-        "links": {
-        }
-      }
-    ],
     "finder": [
       {
         "api_path": "/api/content/eu-withdrawal-act-2018-statutory-instruments",

--- a/formats/shared/base_links.jsonnet
+++ b/formats/shared/base_links.jsonnet
@@ -18,7 +18,5 @@
   original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   lead_organisations: "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
   suggested_ordered_related_items: "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
-  facet_groups: "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-  facet_values: "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
   finder: "Powers links from content back to finders the content is surfaced on"
 }

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -272,8 +272,6 @@ module SchemaGenerator
       ALLOWED_KEYS = %w[description required minItems maxItems].freeze
       LINKS_WITHOUT_BASE_PATHS = %w[
         facets
-        facet_groups
-        facet_values
         ordered_board_members
         ordered_chief_professional_officers
         ordered_contacts


### PR DESCRIPTION
Related to: 
* https://github.com/alphagov/finder-frontend/pull/2835
* https://github.com/alphagov/search-api/pull/2422

Trello: https://trello.com/c/EOLde8PE

`facet_groups` and `facet_values` were created to support the EU Exit Business Support Finder [1]. 
This finder was decommissioned in February 2020 [2], so support for these types is no longer needed.

[1]: https://github.com/alphagov/content-tagger/blob/main/docs/arch/adr-001-links-based-facets.md
[2]: https://github.com/alphagov/finder-frontend/pull/1949