### PR TITLE
Update world location news to remove facet groups

### DIFF
--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -249,14 +249,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -267,14 +267,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/frontend_links"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -381,14 +373,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/world_location_news/publisher_v2/links.json
+++ b/dist/formats/world_location_news/publisher_v2/links.json
@@ -10,14 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "facet_groups": {
-          "description": "Prototype-stage metadata tagging tree roots for this content item. A content item my belong to many facet groups without having any specific facet_values links.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "facet_values": {
-          "description": "Prototype-stage metadata tagging values for this content item, a content item can be linked to many facet values from varying facet groups.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"


### PR DESCRIPTION
We have recently added a schema for world location news. However, just before this change was merged another change that removed facet groups from the shared definitions was merged, meaning the world location news change would not build as the schema files were built with the outdated definitions.