### PR TITLE
Add location type to World Location news page

### DIFF
--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -484,6 +484,13 @@
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
+        },
+        "world_location_news_type": {
+          "type": "string",
+          "enum": [
+            "international_delegation",
+            "world_location"
+          ]
         }
       }
     },

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -576,6 +576,13 @@
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
+        },
+        "world_location_news_type": {
+          "type": "string",
+          "enum": [
+            "international_delegation",
+            "world_location"
+          ]
         }
       }
     },

--- a/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/dist/formats/world_location_news/publisher_v2/schema.json
@@ -364,6 +364,13 @@
         },
         "ordered_featured_links": {
           "$ref": "#/definitions/ordered_featured_links"
+        },
+        "world_location_news_type": {
+          "type": "string",
+          "enum": [
+            "international_delegation",
+            "world_location"
+          ]
         }
       }
     },

--- a/formats/world_location_news.jsonnet
+++ b/formats/world_location_news.jsonnet
@@ -18,6 +18,13 @@
         ordered_featured_documents: {
           "$ref": "#/definitions/ordered_featured_documents",
         },
+        "world_location_news_type": {
+          "type": "string",
+          "enum": [
+            "international_delegation",
+            "world_location"
+          ]
+        },
       },
     },
   },


### PR DESCRIPTION
This is required so we can add a label to the World Location News page telling users whether the news relates to a World Location or International Delegation.

[Trello card](https://trello.com/c/zxDhAkI3)