### PR TITLE
Read ruby version from .ruby-version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby File.read(".ruby-version").chomp
+
 gem "json-schema"
 gem "jsonnet"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,5 +96,8 @@ DEPENDENCIES
   simplecov
   sinatra
 
+RUBY VERSION
+   ruby 2.7.6
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This is needed so that the app gets deployed correctly to Heroku.

https://trello.com/c/aSPjC2s0/2955-remove-dependencies-from-eol-heroku-stacks-3