### PR TITLE
Remove the enum on role_payment_type

### DIFF
--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -338,11 +338,6 @@
           "type": [
             "string",
             "null"
-          ],
-          "enum": [
-            "Unpaid",
-            "Paid as a Parliamentary Secretary",
-            null
           ]
         },
         "seniority": {

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -449,11 +449,6 @@
           "type": [
             "string",
             "null"
-          ],
-          "enum": [
-            "Unpaid",
-            "Paid as a Parliamentary Secretary",
-            null
           ]
         },
         "seniority": {

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -226,11 +226,6 @@
           "type": [
             "string",
             "null"
-          ],
-          "enum": [
-            "Unpaid",
-            "Paid as a Parliamentary Secretary",
-            null
           ]
         },
         "seniority": {

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -40,11 +40,6 @@
             "string",
             "null",
           ],
-          enum: [
-            "Unpaid",
-            "Paid as a Parliamentary Secretary",
-            null,
-          ],
         },
         supports_historical_accounts: {
           type: "boolean",


### PR DESCRIPTION
The Role content type defines a role_payment_type field. It was previously defined as an enum both in this repo, and also in the [downstream app Whitehall][1] which publishes Roles.

We've had a request to add new values to the select list of Role Payment Types in Whitehall. However this would require updating the enum lists in both repositories (i.e. govuk-content-schemas and Whitehall) with the new values – which leads to duplicated effort.

After some digging, we learned that the role_payment_type field is only [used by the frontend][2] to output directly [on the page][3]. It's not used for filtering, sorting, or any other functionality that would reasonably warrant the need for the field to be an enum. In other words: the allowed values in this field don't need to be tightly controlled with a 'contract' in this govuk-content-schemas repo.

I've therefore removed the enum restriction on this field so that it'll accept _any_ string value. We can then maintain the select list of Role Payment Types directly in Whitehall without duplicated effort.

[1]: https://github.com/alphagov/whitehall/blob/26f54ba8ac13ef5c2da8ba4c14a6dd1b610ded0d/app/models/role_payment_type.rb
[2]: https://github.com/alphagov/collections/blob/0b0fa601b59ae8b84762bf2bd36c3cd426618504/app/presenters/organisations/people_presenter.rb#L83
[3]: https://github.com/alphagov/collections/blob/bb488b6e448f9c49f1f56608dc0bf0781329c039/app/views/organisations/_related_people.html.erb#L18

---

Trello: https://trello.com/c/kR8a5bja/732-new-paid-type-for-roles-in-whitehall