### PR TITLE
Change report type for Marine Accident Investigation Branch reports

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2269,7 +2269,7 @@
             "investigation-report",
             "investigation-report-on-behalf-of-red-ensign-group",
             "safety-bulletin",
-            "completed-preliminary-assessment",
+            "completed-preliminary-examination",
             "overseas-report",
             "discontinued-investigation"
           ]

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2375,7 +2375,7 @@
             "investigation-report",
             "investigation-report-on-behalf-of-red-ensign-group",
             "safety-bulletin",
-            "completed-preliminary-assessment",
+            "completed-preliminary-examination",
             "overseas-report",
             "discontinued-investigation"
           ]

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2060,7 +2060,7 @@
             "investigation-report",
             "investigation-report-on-behalf-of-red-ensign-group",
             "safety-bulletin",
-            "completed-preliminary-assessment",
+            "completed-preliminary-examination",
             "overseas-report",
             "discontinued-investigation"
           ]

--- a/examples/finder/frontend/maib-reports.json
+++ b/examples/finder/frontend/maib-reports.json
@@ -56,7 +56,7 @@
           },
           {
             "label": "Completed preliminary assessment",
-            "value": "completed-preliminary-assessment"
+            "value": "completed-preliminary-examination"
           },
           {
             "label": "Overseas report",

--- a/examples/specialist_document/frontend/maib-reports.json
+++ b/examples/specialist_document/frontend/maib-reports.json
@@ -135,7 +135,7 @@
                 },
                 {
                   "label": "Completed preliminary assessment",
-                  "value": "completed-preliminary-assessment"
+                  "value": "completed-preliminary-examination"
                 },
                 {
                   "label": "Overseas report",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -2035,7 +2035,7 @@
           "investigation-report",
           "investigation-report-on-behalf-of-red-ensign-group",
           "safety-bulletin",
-          "completed-preliminary-assessment",
+          "completed-preliminary-examination",
           "overseas-report",
           "discontinued-investigation",
         ],


### PR DESCRIPTION
Changing label only (partially reverting previous PR)
 [Trello card](https://trello.com/c/6OoRo5vK/708-change-report-type-for-marine-accident-investigation-branch-reports)
