### PR TITLE
Add judges to 'utaac-decision.json'

### DIFF
--- a/examples/specialist_document/frontend/utaac-decision.json
+++ b/examples/specialist_document/frontend/utaac-decision.json
@@ -2168,6 +2168,10 @@
                   "value": "charles-w"
                 },
                 {
+                  "label": "Citron, Z",
+                  "value": "citron-z"
+                },
+                {
                   "label": "Cole, G",
                   "value": "cole-g"
                 },
@@ -2282,6 +2286,10 @@
                 {
                   "label": "Machin, K",
                   "value": "machin-k"
+                },
+                {
+                  "label": "Macmillan, M",
+                  "value": "macmillan-m"
                 },
                 {
                   "label": "Mark, M",


### PR DESCRIPTION
## Description

We've had a request to add some judges to the judges filter for `utaac_decsision.json` 

## Trello card 

https://trello.com/c/SqwF3iHI/826-5106299-add-2-judges-to-filter-on-administrative-appeals-tribunal-decisions-content-change-request-hm-courts-tribunals-service-h