### PR TITLE
Add puma as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rspec"
 
 # Preview app for examples
 gem "govuk_schemas"
+gem "puma"
 gem "rack-test"
 gem "sinatra"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     minitest (5.16.3)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.8)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -38,6 +39,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (4.0.6)
+    puma (5.6.5)
+      nio4r (~> 2.0)
     rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
@@ -110,6 +113,7 @@ DEPENDENCIES
   json-schema
   jsonnet (~> 0.4.0)
   pry-byebug
+  puma
   rack-test
   rake
   rspec


### PR DESCRIPTION
This was removed from the standard lib in ruby 3. It's required for the preview app.