### PR TITLE
Add additional links for International Delegations

### DIFF
--- a/dist/formats/world_location_news/frontend/schema.json
+++ b/dist/formats/world_location_news/frontend/schema.json
@@ -269,6 +269,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
+        "ordered_contacts": {
+          "description": "Contact details for this World Location (only used for International Delegations)",
+          "$ref": "#/definitions/frontend_links"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -333,6 +337,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "worldwide_organisations": {
+          "description": "Linked Worldwide Organisations (only used for International Delegations)",
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }

--- a/dist/formats/world_location_news/notification/schema.json
+++ b/dist/formats/world_location_news/notification/schema.json
@@ -287,6 +287,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
+        "ordered_contacts": {
+          "description": "Contact details for this World Location (only used for International Delegations)",
+          "$ref": "#/definitions/frontend_links"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -352,6 +356,10 @@
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "worldwide_organisations": {
+          "description": "Linked Worldwide Organisations (only used for International Delegations)",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -383,6 +391,10 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_contacts": {
+          "description": "Contact details for this World Location (only used for International Delegations)",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -425,6 +437,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "description": "Linked Worldwide Organisations (only used for International Delegations)",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/dist/formats/world_location_news/publisher_v2/links.json
+++ b/dist/formats/world_location_news/publisher_v2/links.json
@@ -26,6 +26,10 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
+        "ordered_contacts": {
+          "description": "Contact details for this World Location (only used for International Delegations)",
+          "$ref": "#/definitions/guid_list"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"
@@ -66,6 +70,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "description": "Linked Worldwide Organisations (only used for International Delegations)",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/formats/world_location_news.jsonnet
+++ b/formats/world_location_news.jsonnet
@@ -28,4 +28,8 @@
       },
     },
   },
+  links: (import "shared/base_links.jsonnet") + {
+    ordered_contacts: "Contact details for this World Location (only used for International Delegations)",
+    worldwide_organisations: "Linked Worldwide Organisations (only used for International Delegations)",
+  },
 }


### PR DESCRIPTION
International Delegations have a number of additional links required to present their content outside of Whitehall.

Presentation of these links was added in https://github.com/alphagov/whitehall/pull/7023.

We do not need to add `organisations` as this is already present in the base links we inherit.

[Trello card](https://trello.com/c/4FWd2mRD/363-add-international-delegation-page-content-to-their-content-item)