### PR TITLE
Remove mainstream browse origin from Topic schema

### DIFF
--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -300,10 +300,6 @@
         },
         "internal_name": {
           "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "mainstream_browse_origin": {
-          "description": "Content id of Mainstream browse page the topic originated from as a part of unified topic system work",
-          "type": "string"
         }
       }
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -396,10 +396,6 @@
         },
         "internal_name": {
           "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "mainstream_browse_origin": {
-          "description": "Content id of Mainstream browse page the topic originated from as a part of unified topic system work",
-          "type": "string"
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -176,10 +176,6 @@
         },
         "internal_name": {
           "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "mainstream_browse_origin": {
-          "description": "Content id of Mainstream browse page the topic originated from as a part of unified topic system work",
-          "type": "string"
         }
       }
     },

--- a/formats/topic.jsonnet
+++ b/formats/topic.jsonnet
@@ -10,10 +10,6 @@
         },
         groups: {
           "$ref": "#/definitions/topic_groups",
-        },
-        mainstream_browse_origin: {
-          type: "string",
-          description: "Content id of Mainstream browse page the topic originated from as a part of unified topic system work"
         }
       },
     },


### PR DESCRIPTION
It's no longer needed as we will not be merging the two topic systems.

[Trello](https://trello.com/c/4CjEsirD/117-remove-code-related-to-topic-merging)